### PR TITLE
#1 [feat] logback 초기 설정

### DIFF
--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,0 +1,14 @@
+<included>
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.FileAppender">
+        <file>/home/ubuntu/app/logs/error/error-${BY_DATE}.log</file>
+        <append>true</append>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,0 +1,14 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.FileAppender">
+        <file>/home/ubuntu/app/logs/info/info-${BY_DATE}.log</file>
+        <append>true</append>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,23 @@
+<configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd'T'HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+    <springProfile name="local">
+        <include resource="console-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local">
+        <include resource="file-info-appender.xml"/>
+        <include resource="file-error-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="FILE-ERROR"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 관련 이슈번호
* Closes #1 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 2h / 10m

## 해결하려는 문제가 무엇인가요?
* 로컬 환경에서는 콘솔로 로그를 확인할 수 있다.
* 배포 환경에서는 요일별, 레벨별로 로그를 파일에 저장할 수 있다.

## 어떻게 해결했나요?
* local 환경에서는 똑같이 console 을 통해서 log를 확인할 수 있습니다.
* 배포 환경에서는 log를 찍으면 console이 아닌 파일에 저장됩니다.
    * 이 때, info 레벨과 error 레벨을 구분하였습니다.
        *  200, 400 에러는 info 레벨 파일에 작성
        * 500 에러는 error 레벨 파일에 작성
* 추후에 모든 통신의 header 값과 body 값을 로깅하는 기능을 만든다면, 배포 환경에서 에러가 발생했을 때 이 점 참고하여 각 상황에 맞는 파일을 확인하시면 됩니다.
 
## 추가
logback-spring.xml 파일을 보면 `<springProfile name="local">` 코드가 있습니다.
이는 springProfile name이 local일 때 console로 로그를 본다는 뜻이기 때문에
해당 PR이 머지가 된다면

1. 사진과 같은 상단에 있는 Application을 클릭한 뒤, edit configurations... 를 클릭한다.
![image](https://github.com/TEAM-MODEE/modee-server/assets/82709044/697b9f58-2b70-47e4-a9d5-6c0a627fa04a)

2. Active Profile 의 이름에 local을 넣고, 적용한 뒤 저장한다.
![image](https://github.com/TEAM-MODEE/modee-server/assets/82709044/684369f7-01a6-4988-ad98-dc0572509a7a)

3. 그 후 다시 빌드를 하면 console에 로그가 찍히는 것을 볼 수 있습니다! 참고해주세요!