### PR TITLE
[feat] CORS 관련 config 파일 작성

### DIFF
--- a/src/main/java/com/moddy/server/config/cors/WebConfig.java
+++ b/src/main/java/com/moddy/server/config/cors/WebConfig.java
@@ -1,0 +1,21 @@
+package com.moddy.server.config.cors;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173", "http://localhost:8080")
+                .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.DELETE.name())
+                .allowedHeaders("Authorization", "Content-Type")
+                .exposedHeaders("Authorization")
+                .allowCredentials(true)
+                .maxAge(3000);
+    }
+}

--- a/src/main/java/com/moddy/server/config/cors/WebConfig.java
+++ b/src/main/java/com/moddy/server/config/cors/WebConfig.java
@@ -11,10 +11,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173", "http://localhost:8080")
+                .allowedOriginPatterns("*")
                 .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.DELETE.name())
                 .allowedHeaders("Authorization", "Content-Type")
-                .exposedHeaders("Authorization")
                 .allowCredentials(true)
                 .maxAge(3000);
     }


### PR DESCRIPTION
## 관련 이슈번호
* Closes #27 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
1h/1h

## 해결하려는 문제가 무엇인가요?
CORS 에러를 방지하기 위한 설정파일을 작성했습니다.

## 어떻게 해결했나요?
``` java
public void addCorsMappings(final CorsRegistry registry) {
        registry.addMapping("/**")
                .allowedOrigins("http://localhost:5173", "http://localhost:8080")
                .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.DELETE.name())
                .allowedHeaders("Authorization", "Content-Type")
                .exposedHeaders("Authorization")
                .allowCredentials(true)
                .maxAge(3000);
    }
```

`.allowedOrigins("http://localhost:5173", "http://localhost:8080")` 
: 클라이언트의 5173 , 서버테스트 포트인 8080를 열어뒀습니다!
<br>
` .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.DELETE.name())` 
: 저희 개발할때 사용하는 Method만 열어뒀습니다.
<br>
`.allowedHeaders("Authorization", "Content-Type")`
: 클라이언트 측의 CORS 요청에 허용되는 헤더를 지정합니다.
<br>
`.exposedHeaders("Authorization")`
 : jwt토큰관련 클라이언트 선생님들이 header에 jwt 토큰 볼 수 있도록 하는 코드 입니다. [해당 링크 참고해서 이 이유때문에 작성했습니다](https://velog.io/@skyjoon34/CORS-CrossOrigin-exposedHeader-allowedHeader)
<br>
`.allowCredentials(true)` 
: 클라이언트 측에 대한 응답에 credentials(예: 쿠키, 인증 헤더)를 포함할 수 있는지 여부를 지정합니다.
<br>
`.maxAge(3000)` 
: 원하는 시간만큼 pre-flight 리퀘스트를 캐싱 해둘 수 있습니다.
<br>

## 잘 모르겠어요
.allowedHeaders("Authorization", "Content-Type") 부분과 .exposedHeaders("Authorization") 부분은 이전에 사용해본 적이 없어서 우리 프로젝트에 해당 케이스들만 적용하는 것이 맞는건지 궁금합니다!