### PR TITLE
#19 [feat] 매 통신마다 request header & body , response 값을 로깅하는 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/moddy/server/common/exception/GlobalControllerExceptionAdvice.java
+++ b/src/main/java/com/moddy/server/common/exception/GlobalControllerExceptionAdvice.java
@@ -18,8 +18,6 @@ import static com.moddy.server.common.exception.enums.ErrorCode.METHOD_NOT_ALLOW
 @Slf4j
 @RestControllerAdvice
 public class GlobalControllerExceptionAdvice {
-    private final static String START_ERROR = "================================================NEW===============================================\n";
-
     /**
      * 400 Bad Request
      */
@@ -73,7 +71,7 @@ public class GlobalControllerExceptionAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     protected ErrorResponse handleException(final Exception error) {
-        log.error(START_ERROR + error.getMessage(), error);
+        log.error(error.getMessage(), error);
         return ErrorResponse.error(INTERNAL_SERVER_EXCEPTION);
     }
 }

--- a/src/main/java/com/moddy/server/common/filter/HttpContentCacheFilter.java
+++ b/src/main/java/com/moddy/server/common/filter/HttpContentCacheFilter.java
@@ -1,0 +1,24 @@
+package com.moddy.server.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+
+@Component
+public class HttpContentCacheFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappingResponse = new ContentCachingResponseWrapper(response);
+
+        filterChain.doFilter(wrappingRequest, wrappingResponse);
+        wrappingResponse.copyBodyToResponse();
+    }
+}

--- a/src/main/java/com/moddy/server/config/aspect/LoggingAspect.java
+++ b/src/main/java/com/moddy/server/config/aspect/LoggingAspect.java
@@ -1,0 +1,91 @@
+package com.moddy.server.config.aspect;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String START_LOG = "================================================NEW===============================================\n";
+    private static final String END_LOG = "================================================END===============================================\n";
+
+    @Pointcut("execution(* com.moddy.server.controller..*(..)) || ( execution(* com.moddy.server.common.exception..*(..)) && !execution(* com.moddy.server.common.exception.GlobalControllerExceptionAdvice.handleException*(..)))")
+    public void controllerInfoLevelExecute() {
+    }
+
+    @Pointcut("execution(* com.moddy.server.common.exception.GlobalControllerExceptionAdvice.handleException*(..))")
+    public void controllerErrorLevelExecute() {
+    }
+
+    @Around("com.moddy.server.config.aspect.LoggingAspect.controllerInfoLevelExecute()")
+    public Object requestInfoLevelLogging(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+        long startAt = System.currentTimeMillis();
+        Object returnValue = proceedingJoinPoint.proceed(proceedingJoinPoint.getArgs());
+        long endAt = System.currentTimeMillis();
+
+        log.info(getCommunicationData(request, cachingRequest, startAt, endAt, returnValue));
+        return returnValue;
+    }
+
+    @Around("com.moddy.server.config.aspect.LoggingAspect.controllerErrorLevelExecute()")
+    public Object requestErrorLevelLogging(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+        long startAt = System.currentTimeMillis();
+        Object returnValue = proceedingJoinPoint.proceed(proceedingJoinPoint.getArgs());
+        long endAt = System.currentTimeMillis();
+
+        log.error(getCommunicationData(request, cachingRequest, startAt, endAt, returnValue));
+        return returnValue;
+    }
+
+    private String getCommunicationData(
+            HttpServletRequest request,
+            ContentCachingRequestWrapper cachingRequest,
+            long startAt,
+            long endAt,
+            Object returnValue
+    ) throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(START_LOG);
+        sb.append(String.format("====> Request: %s %s ({%d}ms)\n====> *Header = {%s}\n", request.getMethod(), request.getRequestURL(), endAt - startAt, getHeaders(request)));
+        if ("POST".equalsIgnoreCase(request.getMethod())) {
+            sb.append(String.format("====> Body: {%s}\n", objectMapper.readTree(cachingRequest.getContentAsByteArray())));
+        }
+        if (returnValue != null) {
+            sb.append(String.format("====> Response: {%s}\n", returnValue));
+        }
+        sb.append(END_LOG);
+        return sb.toString();
+    }
+
+    private Map<String, Object> getHeaders(HttpServletRequest request) {
+        Map<String, Object> headerMap = new HashMap<>();
+
+        Enumeration<String> headerArray = request.getHeaderNames();
+        while (headerArray.hasMoreElements()) {
+            String headerName = headerArray.nextElement();
+            headerMap.put(headerName, request.getHeader(headerName));
+        }
+        return headerMap;
+    }
+}


### PR DESCRIPTION
## 관련 이슈번호
* Closes #19 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 1h / 2h

## 해결하려는 문제가 무엇인가요?
매 통신마다 request header & body , response 값을 로깅하는 기능 구현하기
- 기능 1
200 ~ 400 에러는 info 레벨로 로깅됩니다.
`requestInfoLevelLogging()` 메서드를 통해
request header, body 값과 response 값을 로깅합니다.

- 기능 2
500 에러는 error 레벨로 로깅됩니다.
`requestErrorLevelLogging()` 메서드를 통해
request header, body 값과 response 값을 로깅합니다.

## 어떻게 해결했나요?
aop를 활용해서 controller에 들어오는 값을 전부 로깅하는 기능을 구현했습니다.

