### PR TITLE
#39 [feat] handler method argument resolver 구현

### DIFF
--- a/src/main/java/com/moddy/server/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moddy/server/common/exception/enums/ErrorCode.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    // 400
+    INVALID_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰을 입력했습니다."),
+
     // 401
+    TOKEN_NOT_CONTAINED_EXCEPTION(HttpStatus.UNAUTHORIZED, "Access Token이 필요합니다."),
     TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다. 다시 로그인 해주세요."),
 
     // 500

--- a/src/main/java/com/moddy/server/config/resolver/user/UserId.java
+++ b/src/main/java/com/moddy/server/config/resolver/user/UserId.java
@@ -1,0 +1,11 @@
+package com.moddy.server.config.resolver.user;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/src/main/java/com/moddy/server/config/resolver/user/UserResolver.java
+++ b/src/main/java/com/moddy/server/config/resolver/user/UserResolver.java
@@ -1,0 +1,47 @@
+package com.moddy.server.config.resolver.user;
+
+import com.moddy.server.common.exception.model.BadRequestException;
+import com.moddy.server.common.exception.model.UnAuthorizedException;
+import com.moddy.server.config.jwt.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.moddy.server.common.exception.enums.ErrorCode.INVALID_TOKEN_EXCEPTION;
+import static com.moddy.server.common.exception.enums.ErrorCode.TOKEN_NOT_CONTAINED_EXCEPTION;
+import static com.moddy.server.common.exception.enums.ErrorCode.TOKEN_TIME_EXPIRED_EXCEPTION;
+
+@Component
+@RequiredArgsConstructor
+public class UserResolver implements HandlerMethodArgumentResolver {
+    private final JwtService jwtService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(UserId.class) && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final String token = request.getHeader("Authorization");
+        if (token == null || token.isBlank() || !token.startsWith("Bearer ")) {
+            throw new UnAuthorizedException(TOKEN_NOT_CONTAINED_EXCEPTION);
+        }
+        final String encodedUserId = token.substring("Bearer ".length());
+        if (!jwtService.verifyToken(encodedUserId)) {
+            throw new UnAuthorizedException(TOKEN_TIME_EXPIRED_EXCEPTION);
+        }
+        final String decodedUserId = jwtService.getUserIdInToken(encodedUserId);
+        try {
+            return Long.parseLong(decodedUserId);
+        } catch (NumberFormatException e) {
+            throw new BadRequestException(INVALID_TOKEN_EXCEPTION);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈번호
* Closes #39 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 1h / 1h

## 해결하려는 문제가 무엇인가요?
* authorization 헤더 값으로 들어오는 jwt 토큰을 디코딩해서 Long 타입의 id 값으로 자동으로 변환해주는 기능 구현

## 어떻게 해결했나요?
![image](https://github.com/TEAM-MODDY/moddy-server/assets/82709044/2f4835ce-12ad-42fb-a21a-6ad3ae318dd1)

**동작과정**
* HandlerMethodArgumentResolver 를 통해 Controller 파라미터에 `@UserId` 어노테이션을 감지한다.
* 해당 어노테이션이 있는 Controller 가 실행된다면, Authorization 헤더 값에 jwt 토큰이 온다는 것을 의미하기 때문에,
Authorization 헤더에서 jwt 토큰을 꺼내서 디코딩하는 과정을 거친다.
* 디코딩을 정상적으로 실행한 뒤 Long 타입의 userId를 Controller 파라미터로 전달한다.


`supportsParameter` : Controller 파라미터에 `@UserId` 를 감지한다.
`resolveArgument` : 일련의 과정을 거친 후 해당 파라미터에 주입할 값을 return 한다.