### PR TITLE
#41 [fix] file appender 파일 저장 경로 수정

### DIFF
--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="FILE-ERROR" class="ch.qos.logback.core.FileAppender">
-        <file>/home/ubuntu/app/logs/error/error-${BY_DATE}.log</file>
+        <file>/app/logs/error/error-${BY_DATE}.log</file>
         <append>true</append>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="FILE-INFO" class="ch.qos.logback.core.FileAppender">
-        <file>/home/ubuntu/app/logs/info/info-${BY_DATE}.log</file>
+        <file>/app/logs/info/info-${BY_DATE}.log</file>
         <append>true</append>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>


### PR DESCRIPTION
## 관련 이슈번호
* Closes #41 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 10m/10m

## 해결하려는 문제가 무엇인가요?
* file appender 저장 경로를 /home/ubuntu/app ... 이런 경로로 만들어서
docker 환경에서 루트 디렉토리에 logs 파일이 안보였습니다. 

## 어떻게 해결했나요?
- 이를 해결하기 위해서 /home/ubuntu 경로를 제거해서 /app 으로 시작함으로써 루트 디렉토리에 logs 파일이 보이도록 만들었습니다.