### PR TITLE
#51 [feat] 로그인 api 기능 구현

### DIFF
--- a/src/main/java/com/moddy/server/common/exception/GlobalControllerExceptionAdvice.java
+++ b/src/main/java/com/moddy/server/common/exception/GlobalControllerExceptionAdvice.java
@@ -5,6 +5,7 @@ import com.moddy.server.common.exception.model.BadRequestException;
 import com.moddy.server.common.exception.model.ConflictException;
 import com.moddy.server.common.exception.model.NotFoundException;
 import com.moddy.server.common.exception.model.UnAuthorizedException;
+import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import static com.moddy.server.common.exception.enums.ErrorCode.INTERNAL_SERVER_EXCEPTION;
+import static com.moddy.server.common.exception.enums.ErrorCode.INVALID_TOKEN_EXCEPTION;
 import static com.moddy.server.common.exception.enums.ErrorCode.METHOD_NOT_ALLOWED_EXCEPTION;
 
 @Slf4j
@@ -25,6 +27,13 @@ public class GlobalControllerExceptionAdvice {
     @ExceptionHandler(BadRequestException.class)
     protected ErrorResponse handleBadRequestException(final BadRequestException e) {
         return ErrorResponse.error(e.getErrorCode());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(FeignException.class)
+    protected ErrorResponse handleFeignException(final FeignException e) {
+        System.out.println(e.getMessage());
+        return ErrorResponse.error(INVALID_TOKEN_EXCEPTION);
     }
 
     /**

--- a/src/main/java/com/moddy/server/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moddy/server/common/exception/enums/ErrorCode.java
@@ -9,17 +9,19 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 400
     INVALID_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰을 입력했습니다."),
+    INVALID_KAKAO_CODE_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 카카오 코드를 입력했습니다."),
 
     // 401
     TOKEN_NOT_CONTAINED_EXCEPTION(HttpStatus.UNAUTHORIZED, "Access Token이 필요합니다."),
     TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다. 다시 로그인 해주세요."),
 
-    // 500
-    /**
-     * 405 METHOD_NOT_ALLOWED
-     */
+    // 404
+    USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저는 존재하지 않습니다."),
+
+    // 405 METHOD_NOT_ALLOWED
     METHOD_NOT_ALLOWED_EXCEPTION(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드 입니다."),
 
+    // 500
     INTERNAL_SERVER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/moddy/server/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moddy/server/common/exception/enums/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 400
     INVALID_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰을 입력했습니다."),
+    EMPTY_KAKAO_CODE_EXCEPTION(HttpStatus.BAD_REQUEST, "카카오 코드 값을 입력해 주세요."),
     INVALID_KAKAO_CODE_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 카카오 코드를 입력했습니다."),
 
     // 401

--- a/src/main/java/com/moddy/server/common/exception/enums/SuccessCode.java
+++ b/src/main/java/com/moddy/server/common/exception/enums/SuccessCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
 
-    SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "소셜 로그인 성공");
+    SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "카카오 로그인 성공입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/moddy/server/controller/auth/AuthController.java
+++ b/src/main/java/com/moddy/server/controller/auth/AuthController.java
@@ -1,8 +1,14 @@
 package com.moddy.server.controller.auth;
 
+import com.moddy.server.common.dto.ErrorResponse;
 import com.moddy.server.common.dto.SuccessResponse;
 import com.moddy.server.controller.auth.dto.response.LoginResponseDto;
 import com.moddy.server.service.auth.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +25,13 @@ import static com.moddy.server.common.exception.enums.SuccessCode.SOCIAL_LOGIN_S
 public class AuthController {
     private final AuthService authService;
 
+    @Operation(summary = "로그인 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "카카오 로그인 성공입니다."),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 카카오 코드를 입력했습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 유저는 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping("/login")
     public SuccessResponse<LoginResponseDto> login(@RequestHeader("kakaoCode") String kakaoCode) {
         return SuccessResponse.success(SOCIAL_LOGIN_SUCCESS, authService.login(kakaoCode));

--- a/src/main/java/com/moddy/server/controller/auth/AuthController.java
+++ b/src/main/java/com/moddy/server/controller/auth/AuthController.java
@@ -2,6 +2,7 @@ package com.moddy.server.controller.auth;
 
 import com.moddy.server.common.dto.ErrorResponse;
 import com.moddy.server.common.dto.SuccessResponse;
+import com.moddy.server.config.jwt.JwtService;
 import com.moddy.server.controller.auth.dto.response.LoginResponseDto;
 import com.moddy.server.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +25,7 @@ import static com.moddy.server.common.exception.enums.SuccessCode.SOCIAL_LOGIN_S
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
-    private static final String AUTHORIZATION = "Authorization";
+    private static final String AUTHORIZATION = "authorization";
     private final AuthService authService;
 
     @Operation(summary = "로그인 API")

--- a/src/main/java/com/moddy/server/controller/auth/AuthController.java
+++ b/src/main/java/com/moddy/server/controller/auth/AuthController.java
@@ -23,6 +23,7 @@ import static com.moddy.server.common.exception.enums.SuccessCode.SOCIAL_LOGIN_S
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
+    private static final String AUTHORIZATION = "Authorization";
     private final AuthService authService;
 
     @Operation(summary = "로그인 API")
@@ -33,7 +34,7 @@ public class AuthController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/login")
-    public SuccessResponse<LoginResponseDto> login(@RequestHeader("kakaoCode") String kakaoCode) {
+    public SuccessResponse<LoginResponseDto> login(@RequestHeader(AUTHORIZATION) String kakaoCode) {
         return SuccessResponse.success(SOCIAL_LOGIN_SUCCESS, authService.login(kakaoCode));
     }
 }

--- a/src/main/java/com/moddy/server/controller/auth/AuthController.java
+++ b/src/main/java/com/moddy/server/controller/auth/AuthController.java
@@ -1,0 +1,26 @@
+package com.moddy.server.controller.auth;
+
+import com.moddy.server.common.dto.SuccessResponse;
+import com.moddy.server.controller.auth.dto.response.LoginResponseDto;
+import com.moddy.server.service.auth.AuthService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.moddy.server.common.exception.enums.SuccessCode.SOCIAL_LOGIN_SUCCESS;
+
+@Tag(name = "로그인 및 회원 가입", description = "로그인 및 회원 가입 관련 API 입니다.")
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public SuccessResponse<LoginResponseDto> login(@RequestHeader("kakaoCode") String kakaoCode) {
+        return SuccessResponse.success(SOCIAL_LOGIN_SUCCESS, authService.login(kakaoCode));
+    }
+}

--- a/src/main/java/com/moddy/server/controller/auth/dto/request/SocialLoginRequest.java
+++ b/src/main/java/com/moddy/server/controller/auth/dto/request/SocialLoginRequest.java
@@ -1,6 +1,0 @@
-package com.moddy.server.controller.auth.dto.request;
-
-public record SocialLoginRequest(
-        String code
-) {
-}

--- a/src/main/java/com/moddy/server/controller/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/moddy/server/controller/auth/dto/response/LoginResponseDto.java
@@ -1,0 +1,4 @@
+package com.moddy.server.controller.auth.dto.response;
+
+public record LoginResponseDto(String accessToken, String refreshToken, String role) {
+}

--- a/src/main/java/com/moddy/server/controller/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/moddy/server/controller/auth/dto/response/SocialLoginResponse.java
@@ -1,7 +1,0 @@
-package com.moddy.server.controller.auth.dto.response;
-
-
-public record SocialLoginResponse(
-        String userId
-) {
-}

--- a/src/main/java/com/moddy/server/domain/user/User.java
+++ b/src/main/java/com/moddy/server/domain/user/User.java
@@ -10,8 +10,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 
 @Entity
+@Getter
 @Inheritance(strategy = InheritanceType.JOINED)
 public class User extends BaseTimeEntity {
 

--- a/src/main/java/com/moddy/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moddy/server/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.moddy.server.domain.user.repository;
+
+import com.moddy.server.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    public Optional<User> findByKakaoId(String kakaoId);
+}

--- a/src/main/java/com/moddy/server/external/kakao/dto/response/KakaoAccessTokenResponse.java
+++ b/src/main/java/com/moddy/server/external/kakao/dto/response/KakaoAccessTokenResponse.java
@@ -1,7 +1,8 @@
 package com.moddy.server.external.kakao.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoAccessTokenResponse(String accessToken, String refreshToken) {
-    public static KakaoAccessTokenResponse of(String accessToken, String refreshToken) {
-        return new KakaoAccessTokenResponse(accessToken, refreshToken);
-    }
 }

--- a/src/main/java/com/moddy/server/external/kakao/dto/response/KakaoUserResponse.java
+++ b/src/main/java/com/moddy/server/external/kakao/dto/response/KakaoUserResponse.java
@@ -1,4 +1,4 @@
 package com.moddy.server.external.kakao.dto.response;
 
-
-public record KakaoUserResponse(Long id) {}
+public record KakaoUserResponse(Long id) {
+}

--- a/src/main/java/com/moddy/server/external/kakao/service/KakaoSocialService.java
+++ b/src/main/java/com/moddy/server/external/kakao/service/KakaoSocialService.java
@@ -1,15 +1,15 @@
 package com.moddy.server.external.kakao.service;
 
-
+import com.moddy.server.common.exception.model.BadRequestException;
 import com.moddy.server.external.kakao.dto.response.KakaoAccessTokenResponse;
 import com.moddy.server.external.kakao.dto.response.KakaoUserResponse;
 import com.moddy.server.external.kakao.feign.KakaoApiClient;
 import com.moddy.server.external.kakao.feign.KakaoAuthApiClient;
-import com.moddy.server.controller.auth.dto.request.SocialLoginRequest;
-import com.moddy.server.controller.auth.dto.response.SocialLoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import static com.moddy.server.common.exception.enums.ErrorCode.INVALID_KAKAO_CODE_EXCEPTION;
 
 
 @Service
@@ -18,27 +18,23 @@ public class KakaoSocialService extends SocialService {
 
     @Value("${kakao.client-id}")
     private String clientId;
-
-
     private final KakaoAuthApiClient kakaoAuthApiClient;
     private final KakaoApiClient kakaoApiClient;
 
     @Override
-    public SocialLoginResponse login(SocialLoginRequest request) {
-
-
+    public String getIdFromKakao(String kakaoCode) {
+        if (kakaoCode == null) throw new BadRequestException(INVALID_KAKAO_CODE_EXCEPTION);
         // Authorization code로 Access Token 불러오기
         KakaoAccessTokenResponse tokenResponse = kakaoAuthApiClient.getOAuth2AccessToken(
                 "authorization_code",
                 clientId,
                 "http://localhost:3000/login/oauth2/code/kakao",
-                request.code()
+                kakaoCode
         );
 
         // Access Token으로 유저 정보 불러오기
         KakaoUserResponse userResponse = kakaoApiClient.getUserInformation("Bearer " + tokenResponse.accessToken());
 
-        return new SocialLoginResponse(String.valueOf(userResponse.id()));
-
+        return String.valueOf(userResponse.id());
     }
 }

--- a/src/main/java/com/moddy/server/external/kakao/service/KakaoSocialService.java
+++ b/src/main/java/com/moddy/server/external/kakao/service/KakaoSocialService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import static com.moddy.server.common.exception.enums.ErrorCode.EMPTY_KAKAO_CODE_EXCEPTION;
 import static com.moddy.server.common.exception.enums.ErrorCode.INVALID_KAKAO_CODE_EXCEPTION;
 
 
@@ -23,7 +24,7 @@ public class KakaoSocialService extends SocialService {
 
     @Override
     public String getIdFromKakao(String kakaoCode) {
-        if (kakaoCode == null) throw new BadRequestException(INVALID_KAKAO_CODE_EXCEPTION);
+        if (kakaoCode == null) throw new BadRequestException(EMPTY_KAKAO_CODE_EXCEPTION);
         // Authorization code로 Access Token 불러오기
         KakaoAccessTokenResponse tokenResponse = kakaoAuthApiClient.getOAuth2AccessToken(
                 "authorization_code",

--- a/src/main/java/com/moddy/server/external/kakao/service/SocialService.java
+++ b/src/main/java/com/moddy/server/external/kakao/service/SocialService.java
@@ -1,10 +1,7 @@
 package com.moddy.server.external.kakao.service;
 
 
-import com.moddy.server.controller.auth.dto.request.SocialLoginRequest;
-import com.moddy.server.controller.auth.dto.response.SocialLoginResponse;
-
 public abstract class SocialService {
-    public abstract SocialLoginResponse login(SocialLoginRequest request);
+    public abstract String getIdFromKakao(String kakaoCode);
 
 }

--- a/src/main/java/com/moddy/server/service/auth/AuthService.java
+++ b/src/main/java/com/moddy/server/service/auth/AuthService.java
@@ -1,0 +1,29 @@
+package com.moddy.server.service.auth;
+
+import com.moddy.server.common.dto.TokenPair;
+import com.moddy.server.common.exception.model.NotFoundException;
+import com.moddy.server.config.jwt.JwtService;
+import com.moddy.server.controller.auth.dto.response.LoginResponseDto;
+import com.moddy.server.domain.user.User;
+import com.moddy.server.domain.user.repository.UserRepository;
+import com.moddy.server.external.kakao.service.KakaoSocialService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.moddy.server.common.exception.enums.ErrorCode.USER_NOT_FOUND_EXCEPTION;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final JwtService jwtService;
+    private final KakaoSocialService kakaoSocialService;
+    private final UserRepository userRepository;
+
+    public LoginResponseDto login(final String kakaoCode) {
+        String kakaoId = kakaoSocialService.getIdFromKakao(kakaoCode);
+        User user = userRepository.findByKakaoId(kakaoId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_EXCEPTION));
+        TokenPair tokenPair = jwtService.generateTokenPair(String.valueOf(user.getId()));
+
+        return new LoginResponseDto(tokenPair.accessToken(), tokenPair.refreshToken(), user.getRole().name());
+    }
+}


### PR DESCRIPTION
## 관련 이슈번호
* Closes #51 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 1h / 1h

## 해결하려는 문제가 무엇인가요?
* 로그인 api 기능 구현

## 어떻게 해결했나요?
유저가 헤더 값으로 주는 kakao code 값을 kakao에 요청해서 kakao id 값을 받습니다.
해당 kakaoid가 있는 user를 쭉 조회합니다.
조회 후 user id 를 access token 과 refresh token을 만든 후 role 과 함께 반환합니다.

- kakaoCode 가 없으면 400을 반환합니다.
- kakaoid가 조회되지 않으면 404를 반환합니다.