### PR TITLE
#57 [feat] kakao token resolver 추가

### DIFF
--- a/src/main/java/com/moddy/server/config/WebConfig.java
+++ b/src/main/java/com/moddy/server/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.moddy.server.config;
 
+import com.moddy.server.config.resolver.kakao.KakaoCodeResolver;
 import com.moddy.server.config.resolver.user.UserResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
     private final UserResolver userResolver;
+    private final KakaoCodeResolver kakaoCodeResolver;
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
@@ -28,5 +30,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(userResolver);
+        resolvers.add(kakaoCodeResolver);
+
     }
 }

--- a/src/main/java/com/moddy/server/config/resolver/kakao/KakaoCode.java
+++ b/src/main/java/com/moddy/server/config/resolver/kakao/KakaoCode.java
@@ -1,0 +1,11 @@
+package com.moddy.server.config.resolver.kakao;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KakaoCode {
+}

--- a/src/main/java/com/moddy/server/config/resolver/kakao/KakaoCodeResolver.java
+++ b/src/main/java/com/moddy/server/config/resolver/kakao/KakaoCodeResolver.java
@@ -1,0 +1,35 @@
+package com.moddy.server.config.resolver.kakao;
+
+import com.moddy.server.common.exception.model.UnAuthorizedException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.moddy.server.common.exception.enums.ErrorCode.EMPTY_KAKAO_CODE_EXCEPTION;
+import static com.moddy.server.common.exception.enums.ErrorCode.TOKEN_NOT_CONTAINED_EXCEPTION;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoCodeResolver implements HandlerMethodArgumentResolver {
+    private static final String AUTHORIZATION = "authorization";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(KakaoCode.class) && String.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final String token = request.getHeader(AUTHORIZATION);
+        if (token == null || token.isBlank() || !token.startsWith("Bearer ")) {
+            throw new UnAuthorizedException(EMPTY_KAKAO_CODE_EXCEPTION);
+        }
+        return token.substring("Bearer ".length());
+    }
+}

--- a/src/main/java/com/moddy/server/controller/auth/AuthController.java
+++ b/src/main/java/com/moddy/server/controller/auth/AuthController.java
@@ -2,19 +2,19 @@ package com.moddy.server.controller.auth;
 
 import com.moddy.server.common.dto.ErrorResponse;
 import com.moddy.server.common.dto.SuccessResponse;
-import com.moddy.server.config.jwt.JwtService;
+import com.moddy.server.config.resolver.kakao.KakaoCode;
 import com.moddy.server.controller.auth.dto.response.LoginResponseDto;
 import com.moddy.server.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,7 +25,6 @@ import static com.moddy.server.common.exception.enums.SuccessCode.SOCIAL_LOGIN_S
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
-    private static final String AUTHORIZATION = "authorization";
     private final AuthService authService;
 
     @Operation(summary = "로그인 API")
@@ -36,7 +35,8 @@ public class AuthController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/login")
-    public SuccessResponse<LoginResponseDto> login(@RequestHeader(AUTHORIZATION) String kakaoCode) {
+    @SecurityRequirement(name = "JWT Auth")
+    public SuccessResponse<LoginResponseDto> login(@Parameter(hidden = true) @KakaoCode String kakaoCode) {
         return SuccessResponse.success(SOCIAL_LOGIN_SUCCESS, authService.login(kakaoCode));
     }
 }

--- a/src/main/java/com/moddy/server/external/kakao/service/KakaoSocialService.java
+++ b/src/main/java/com/moddy/server/external/kakao/service/KakaoSocialService.java
@@ -1,6 +1,5 @@
 package com.moddy.server.external.kakao.service;
 
-import com.moddy.server.common.exception.model.BadRequestException;
 import com.moddy.server.external.kakao.dto.response.KakaoAccessTokenResponse;
 import com.moddy.server.external.kakao.dto.response.KakaoUserResponse;
 import com.moddy.server.external.kakao.feign.KakaoApiClient;
@@ -8,9 +7,6 @@ import com.moddy.server.external.kakao.feign.KakaoAuthApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import static com.moddy.server.common.exception.enums.ErrorCode.EMPTY_KAKAO_CODE_EXCEPTION;
-import static com.moddy.server.common.exception.enums.ErrorCode.INVALID_KAKAO_CODE_EXCEPTION;
 
 
 @Service
@@ -24,7 +20,6 @@ public class KakaoSocialService extends SocialService {
 
     @Override
     public String getIdFromKakao(String kakaoCode) {
-        if (kakaoCode == null) throw new BadRequestException(EMPTY_KAKAO_CODE_EXCEPTION);
         // Authorization code로 Access Token 불러오기
         KakaoAccessTokenResponse tokenResponse = kakaoAuthApiClient.getOAuth2AccessToken(
                 "authorization_code",


### PR DESCRIPTION
## 관련 이슈번호
* Closes #57 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 30m / 30m

## 해결하려는 문제가 무엇인가요?
* kakao token 헤더 값으로 들어오게 만들기

## 어떻게 해결했나요?
* resolver를 이용했습니다.

## 사용방법
* kakaoCode 를 헤더 값으로 받을 때, `@Kakao` 어노테이션을 사용해야 합니다.
* 스웨거에서 해당 파라미터를 숨기기 위해서 `@Parameter(hidden = true)` 앞에 붙여야  합니다.
* 스웨거에서 입력한 헤더 값을 받기 위해서 `@SecurityRequirement(name = "JWT Auth")` 을 붙여줘야 합니다.
![image](https://github.com/TEAM-MODDY/moddy-server/assets/82709044/7266090d-6fb7-4e6c-989e-ad8b090af321)
* 스웨거에서 카카오 코드를 넣을 때 위의 이미지 처럼 넣으면 됩니다!!