### PR TITLE
#116 [feat] 로그인 api 리팩토링

### DIFF
--- a/src/main/java/com/moddy/server/common/dto/ErrorDataResponse.java
+++ b/src/main/java/com/moddy/server/common/dto/ErrorDataResponse.java
@@ -1,0 +1,20 @@
+package com.moddy.server.common.dto;
+
+import com.moddy.server.common.exception.enums.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorDataResponse<T> {
+    private final int code;
+    private final String message;
+    private final T data;
+
+    public static <T> ErrorDataResponse<T> error(ErrorCode errorCode, T data) {
+        return new ErrorDataResponse<>(errorCode.getHttpStatus().value(), errorCode.getMessage(), data);
+    }
+}

--- a/src/main/java/com/moddy/server/common/exception/GlobalControllerExceptionAdvice.java
+++ b/src/main/java/com/moddy/server/common/exception/GlobalControllerExceptionAdvice.java
@@ -1,9 +1,12 @@
 package com.moddy.server.common.exception;
 
+import com.moddy.server.common.dto.ErrorDataResponse;
 import com.moddy.server.common.dto.ErrorResponse;
+import com.moddy.server.common.dto.TokenPair;
 import com.moddy.server.common.exception.model.BadRequestException;
 import com.moddy.server.common.exception.model.ConflictException;
 import com.moddy.server.common.exception.model.NotFoundException;
+import com.moddy.server.common.exception.model.NotFoundUserException;
 import com.moddy.server.common.exception.model.UnAuthorizedException;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
@@ -54,6 +57,12 @@ public class GlobalControllerExceptionAdvice {
     @ExceptionHandler(NotFoundException.class)
     protected ErrorResponse handleNotFoundException(final NotFoundException e) {
         return ErrorResponse.error(e.getErrorCode());
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NotFoundUserException.class)
+    protected ErrorDataResponse<TokenPair> handleNotFoundUserException(final NotFoundUserException e) {
+        return ErrorDataResponse.error(e.getErrorCode(), e.getTokenPair());
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/src/main/java/com/moddy/server/common/exception/model/NotFoundUserException.java
+++ b/src/main/java/com/moddy/server/common/exception/model/NotFoundUserException.java
@@ -1,0 +1,15 @@
+package com.moddy.server.common.exception.model;
+
+import com.moddy.server.common.dto.TokenPair;
+import com.moddy.server.common.exception.enums.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotFoundUserException extends ModdyException {
+    private final TokenPair tokenPair;
+
+    public NotFoundUserException(ErrorCode errorCode, TokenPair tokenPair) {
+        super(errorCode);
+        this.tokenPair = tokenPair;
+    }
+}

--- a/src/main/java/com/moddy/server/domain/user/User.java
+++ b/src/main/java/com/moddy/server/domain/user/User.java
@@ -1,10 +1,18 @@
 package com.moddy.server.domain.user;
 
 import com.moddy.server.domain.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
@@ -24,30 +32,23 @@ public class User extends BaseTimeEntity {
     @NotNull
     private String kakaoId;
 
-    @NotNull
     private String name;
 
     @Enumerated(value = EnumType.STRING)
-    @NotNull
     private Gender gender;
 
-    @NotNull
     private String phoneNumber;
 
-    @NotNull
     private Boolean isMarketingAgree;
 
-    @NotNull
     private String profileImgUrl;
 
-    @NotNull
     @Enumerated(EnumType.STRING)
     private Role role;
 
-
-    public Integer getAge(String year){
+    public Integer getAge(String year) {
         LocalDateTime currentDateTime = LocalDateTime.now();
-        Integer age = currentDateTime.getYear() - Integer.parseInt(year) + 1 ;
+        Integer age = currentDateTime.getYear() - Integer.parseInt(year) + 1;
         return age;
     }
 


### PR DESCRIPTION
## 관련 이슈번호
* Closes #116 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 2h / 2h

## 해결하려는 문제가 무엇인가요?
* 로그인 api 리팩토링

## 어떻게 해결했나요?
* 유저가 없는 경우 카카오 id 를 보유한 user를 생성한다.
* 해당 유저의 jwt 토큰을 반환한다.
* 다시 로그인했을 때 카카오 id를 보유한 user가 있지만, 아직 정보가없다면 404를 반환한다.