### PR TITLE
#118 [fix] 디자이너 회원가입 api 수정

### DIFF
--- a/src/main/java/com/moddy/server/controller/auth/AuthController.java
+++ b/src/main/java/com/moddy/server/controller/auth/AuthController.java
@@ -75,7 +75,7 @@ public class AuthController {
         return SuccessResponse.success(SuccessCode.FIND_REGION_LIST_SUCCESS, authService.getRegionList());
     }
 
-    @Operation(summary = "[KAKAO CODE] 디자이너 회원가입 API", description = "디자이너 회원가입 조회 API입니다.")
+    @Operation(summary = "[JWT] 디자이너 회원가입 API", description = "디자이너 회원가입 조회 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "디자이너 회원가입 성공", content = @Content(schema = @Schema(implementation = UserCreateResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -83,12 +83,11 @@ public class AuthController {
     @SecurityRequirement(name = "JWT Auth")
     @PostMapping(value = "/signup/designer", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     SuccessResponse<UserCreateResponse> createDesigner(
-            @Parameter(hidden = true) @KakaoCode String kakaoCode,
+            @Parameter(hidden = true) @UserId Long userId,
             @RequestPart MultipartFile profileImg,
-            @RequestPart DesignerCreateRequest designerInfo,
-            @Parameter(hidden = true) HttpServletRequest servletRequest
+            @RequestPart DesignerCreateRequest designerInfo
     ) {
-        return SuccessResponse.success(SuccessCode.DESIGNER_CREATE_SUCCESS, designerService.createDesigner(servletRequest.getHeader(ORIGIN), kakaoCode, designerInfo, profileImg));
+        return SuccessResponse.success(SuccessCode.DESIGNER_CREATE_SUCCESS, designerService.createDesigner(userId, designerInfo, profileImg));
     }
 
     @Operation(summary = "[KAKAO CODE] 모델 회원가입 API", description = "모델 회원가입 API입니다.")

--- a/src/main/java/com/moddy/server/controller/designer/dto/HairShopDTO.java
+++ b/src/main/java/com/moddy/server/controller/designer/dto/HairShopDTO.java
@@ -1,11 +1,15 @@
 package com.moddy.server.controller.designer.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Builder
 public record HairShopDTO(
+        @Schema(example = "juno")
         String name,
+        @Schema(example = "서울시 강남구")
         String address,
+        @Schema(example = "선릉로 122길")
         String detailAddress
 )
 {

--- a/src/main/java/com/moddy/server/controller/designer/dto/HairShopDto.java
+++ b/src/main/java/com/moddy/server/controller/designer/dto/HairShopDto.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Builder
-public record HairShopDTO(
+public record HairShopDto(
         @Schema(example = "juno")
         String name,
         @Schema(example = "서울시 강남구")

--- a/src/main/java/com/moddy/server/controller/designer/dto/HairShopDto.java
+++ b/src/main/java/com/moddy/server/controller/designer/dto/HairShopDto.java
@@ -13,6 +13,4 @@ public record HairShopDto(
         String detailAddress
 )
 {
-
-
 }

--- a/src/main/java/com/moddy/server/controller/designer/dto/PortfolioDTO.java
+++ b/src/main/java/com/moddy/server/controller/designer/dto/PortfolioDTO.java
@@ -1,11 +1,14 @@
 package com.moddy.server.controller.designer.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 
 @Builder
 public record PortfolioDTO(
+        @Schema(example = "http://instagram")
         String instagramUrl,
+        @Schema(example = "http://naver")
         String naverPlaceUrl
 ) {
 }

--- a/src/main/java/com/moddy/server/controller/designer/dto/PortfolioDto.java
+++ b/src/main/java/com/moddy/server/controller/designer/dto/PortfolioDto.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 
 @Builder
-public record PortfolioDTO(
+public record PortfolioDto(
         @Schema(example = "http://instagram")
         String instagramUrl,
         @Schema(example = "http://naver")

--- a/src/main/java/com/moddy/server/controller/designer/dto/request/DesignerCreateRequest.java
+++ b/src/main/java/com/moddy/server/controller/designer/dto/request/DesignerCreateRequest.java
@@ -10,13 +10,19 @@ import java.util.List;
 
 @Schema
 public record DesignerCreateRequest(
+        @Schema(example = "박경린")
         String name,
+        @Schema(example = "MALE")
         Gender gender,
+        @Schema(example = "01020000000")
         String phoneNumber,
+        @Schema(example = "true")
         Boolean isMarketingAgree,
         HairShopDTO hairShop,
         PortfolioDTO portfolio,
+        @Schema(example = "introduction")
         String introduction,
+        @Schema(example = "http://.kakao")
         String kakaoOpenChatUrl,
         List<DayOfWeek> dayOffs
 ) {

--- a/src/main/java/com/moddy/server/controller/designer/dto/request/DesignerCreateRequest.java
+++ b/src/main/java/com/moddy/server/controller/designer/dto/request/DesignerCreateRequest.java
@@ -1,7 +1,7 @@
 package com.moddy.server.controller.designer.dto.request;
 
-import com.moddy.server.controller.designer.dto.HairShopDTO;
-import com.moddy.server.controller.designer.dto.PortfolioDTO;
+import com.moddy.server.controller.designer.dto.HairShopDto;
+import com.moddy.server.controller.designer.dto.PortfolioDto;
 import com.moddy.server.domain.day_off.DayOfWeek;
 import com.moddy.server.domain.user.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,8 +18,8 @@ public record DesignerCreateRequest(
         String phoneNumber,
         @Schema(example = "true")
         Boolean isMarketingAgree,
-        HairShopDTO hairShop,
-        PortfolioDTO portfolio,
+        HairShopDto hairShop,
+        PortfolioDto portfolio,
         @Schema(example = "introduction")
         String introduction,
         @Schema(example = "http://.kakao")

--- a/src/main/java/com/moddy/server/domain/designer/Designer.java
+++ b/src/main/java/com/moddy/server/domain/designer/Designer.java
@@ -1,14 +1,12 @@
 package com.moddy.server.domain.designer;
 
-import com.moddy.server.domain.user.Gender;
-import com.moddy.server.domain.user.Role;
 import com.moddy.server.domain.user.User;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
-
 
 @Entity
 @Getter

--- a/src/main/java/com/moddy/server/domain/designer/Designer.java
+++ b/src/main/java/com/moddy/server/domain/designer/Designer.java
@@ -2,6 +2,7 @@ package com.moddy.server.domain.designer;
 
 import com.moddy.server.domain.user.User;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +23,9 @@ public class Designer extends User {
     @Embedded
     private Portfolio portfolio;
 
+    @NotNull
     private String introduction;
 
+    @NotNull
     private String kakaoOpenChatUrl;
 }

--- a/src/main/java/com/moddy/server/domain/designer/Designer.java
+++ b/src/main/java/com/moddy/server/domain/designer/Designer.java
@@ -1,18 +1,18 @@
 package com.moddy.server.domain.designer;
 
+import com.moddy.server.domain.user.Gender;
+import com.moddy.server.domain.user.Role;
 import com.moddy.server.domain.user.User;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
@@ -24,12 +24,7 @@ public class Designer extends User {
     @Embedded
     private Portfolio portfolio;
 
-    @NotNull
     private String introduction;
 
-    @NotNull
     private String kakaoOpenChatUrl;
-
-
-
 }

--- a/src/main/java/com/moddy/server/domain/designer/repository/DesignerJpaRepository.java
+++ b/src/main/java/com/moddy/server/domain/designer/repository/DesignerJpaRepository.java
@@ -5,14 +5,12 @@ import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 public interface DesignerJpaRepository extends JpaRepository<Designer, Long> {
     @Modifying(clearAutomatically = true)
     @Query(value = "insert into Designer (id, hair_shop_address, hair_shop_detail_address, hair_shop_name, instagram_url, naver_place_url, introduction, kakao_open_chat_url) VALUES (:id, :hairShopAddress, :hairShopDetailAddress, :hairShopName, :instagramUrl, :naverPlaceUrl, :introduction, :kakaoOpenChatUrl)", nativeQuery = true)
-    @Transactional
     void designerRegister(@Param("id") Long id, @Param("hairShopAddress") String hairShopAddress, @Param("hairShopDetailAddress") String hairShopDetailAddress, @Param("hairShopName") String hairShopName,@Param("instagramUrl") String instagramUrl,@Param("naverPlaceUrl") String naverPlaceUrl,@Param("introduction") String introduction,@Param("kakaoOpenChatUrl") String kakaoOpenChatUrl);
     Optional<Designer> findById(Long userId);
 }

--- a/src/main/java/com/moddy/server/domain/designer/repository/DesignerJpaRepository.java
+++ b/src/main/java/com/moddy/server/domain/designer/repository/DesignerJpaRepository.java
@@ -1,9 +1,18 @@
 package com.moddy.server.domain.designer.repository;
 
 import com.moddy.server.domain.designer.Designer;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 public interface DesignerJpaRepository extends JpaRepository<Designer, Long> {
-
+    @Modifying(clearAutomatically = true)
+    @Query(value = "insert into Designer (id, hair_shop_address, hair_shop_detail_address, hair_shop_name, instagram_url, naver_place_url, introduction, kakao_open_chat_url) VALUES (:id, :hairShopAddress, :hairShopDetailAddress, :hairShopName, :instagramUrl, :naverPlaceUrl, :introduction, :kakaoOpenChatUrl)", nativeQuery = true)
+    @Transactional
+    void designerRegister(@Param("id") Long id, @Param("hairShopAddress") String hairShopAddress, @Param("hairShopDetailAddress") String hairShopDetailAddress, @Param("hairShopName") String hairShopName,@Param("instagramUrl") String instagramUrl,@Param("naverPlaceUrl") String naverPlaceUrl,@Param("introduction") String introduction,@Param("kakaoOpenChatUrl") String kakaoOpenChatUrl);
+    Optional<Designer> findById(Long userId);
 }

--- a/src/main/java/com/moddy/server/domain/user/User.java
+++ b/src/main/java/com/moddy/server/domain/user/User.java
@@ -13,12 +13,14 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @SuperBuilder
 @Inheritance(strategy = InheritanceType.JOINED)
 @NoArgsConstructor

--- a/src/main/java/com/moddy/server/domain/user/User.java
+++ b/src/main/java/com/moddy/server/domain/user/User.java
@@ -13,14 +13,12 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Setter
 @SuperBuilder
 @Inheritance(strategy = InheritanceType.JOINED)
 @NoArgsConstructor
@@ -52,4 +50,14 @@ public class User extends BaseTimeEntity {
         Integer age = currentDateTime.getYear() - Integer.parseInt(year) + 1;
         return age;
     }
+
+    public void update( String name, Gender gender, String phoneNumber, Boolean isMarketingAgree, String profileImgUrl, Role role) {
+        this.name = name;
+        this.gender = gender;
+        this.phoneNumber = phoneNumber;
+        this.isMarketingAgree = isMarketingAgree;
+        this.profileImgUrl = profileImgUrl;
+        this.role = role;
+    }
+
 }

--- a/src/main/java/com/moddy/server/domain/user/User.java
+++ b/src/main/java/com/moddy/server/domain/user/User.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @SuperBuilder
 @Inheritance(strategy = InheritanceType.JOINED)
 @NoArgsConstructor
@@ -24,31 +25,23 @@ public class User extends BaseTimeEntity {
     @NotNull
     private String kakaoId;
 
-    @NotNull
     private String name;
 
     @Enumerated(value = EnumType.STRING)
-    @NotNull
     private Gender gender;
 
-    @NotNull
     private String phoneNumber;
 
-    @NotNull
     private Boolean isMarketingAgree;
 
-    @NotNull
     private String profileImgUrl;
 
-    @NotNull
     @Enumerated(EnumType.STRING)
     private Role role;
-
 
     public Integer getAge(String year){
         LocalDateTime currentDateTime = LocalDateTime.now();
         Integer age = currentDateTime.getYear() - Integer.parseInt(year) + 1 ;
         return age;
     }
-
 }

--- a/src/main/java/com/moddy/server/domain/user/User.java
+++ b/src/main/java/com/moddy/server/domain/user/User.java
@@ -51,7 +51,7 @@ public class User extends BaseTimeEntity {
         return age;
     }
 
-    public void update( String name, Gender gender, String phoneNumber, Boolean isMarketingAgree, String profileImgUrl, Role role) {
+    public void update(String name, Gender gender, String phoneNumber, Boolean isMarketingAgree, String profileImgUrl, Role role) {
         this.name = name;
         this.gender = gender;
         this.phoneNumber = phoneNumber;
@@ -59,5 +59,4 @@ public class User extends BaseTimeEntity {
         this.profileImgUrl = profileImgUrl;
         this.role = role;
     }
-
 }

--- a/src/main/java/com/moddy/server/service/designer/DesignerService.java
+++ b/src/main/java/com/moddy/server/service/designer/DesignerService.java
@@ -90,7 +90,14 @@ public class DesignerService {
         String profileImgUrl = s3Service.uploadProfileImage(profileImg, Role.HAIR_DESIGNER);
 
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
-        Designer designer = designerJpaRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.DESIGNER_NOT_FOUND_EXCEPTION));
+
+        user.setGender(request.gender());
+        user.setName(request.name());
+        user.setPhoneNumber(request.phoneNumber());
+        user.setIsMarketingAgree(request.isMarketingAgree());
+        user.setProfileImgUrl(profileImgUrl);
+        user.setRole(Role.HAIR_DESIGNER);
+
         HairShop hairShop = HairShop.builder()
                 .name(request.hairShop().name())
                 .address(request.hairShop().address())
@@ -100,17 +107,21 @@ public class DesignerService {
                 .instagramUrl(request.portfolio().instagramUrl())
                 .naverPlaceUrl(request.portfolio().naverPlaceUrl())
                 .build();
-
-        designer.setHairShop(hairShop);
-        designer.setPortfolio(portfolio);
-        designer.setIntroduction(request.introduction());
-        designer.setKakaoOpenChatUrl(request.kakaoOpenChatUrl());
-        user.setGender(request.gender());
-        user.setName(request.name());
-        user.setPhoneNumber(request.phoneNumber());
-        user.setIsMarketingAgree(request.isMarketingAgree());
-        user.setProfileImgUrl(profileImgUrl);
-        user.setRole(Role.HAIR_DESIGNER);
+        Designer designer = Designer.builder()
+                .id(user.getId())
+                .hairShop(hairShop)
+                .portfolio(portfolio)
+                .introduction(request.introduction())
+                .kakaoOpenChatUrl(request.kakaoOpenChatUrl())
+                .kakaoId(user.getKakaoId())
+                .name(request.name())
+                .gender(request.gender())
+                .phoneNumber(request.phoneNumber())
+                .isMarketingAgree(request.isMarketingAgree())
+                .profileImgUrl(profileImgUrl)
+                .role(Role.HAIR_DESIGNER)
+                .build();
+        designerJpaRepository.save(designer);
 
         request.dayOffs().stream()
                 .forEach(d -> {

--- a/src/main/java/com/moddy/server/service/designer/DesignerService.java
+++ b/src/main/java/com/moddy/server/service/designer/DesignerService.java
@@ -108,22 +108,8 @@ public class DesignerService {
                 .instagramUrl(request.portfolio().instagramUrl())
                 .naverPlaceUrl(request.portfolio().naverPlaceUrl())
                 .build();
-        Designer designer = Designer.builder()
-                .id(user.getId())
-                .hairShop(hairShop)
-                .portfolio(portfolio)
-                .introduction(request.introduction())
-                .kakaoOpenChatUrl(request.kakaoOpenChatUrl())
-                .kakaoId(user.getKakaoId())
-                .name(request.name())
-                .gender(request.gender())
-                .phoneNumber(request.phoneNumber())
-                .isMarketingAgree(request.isMarketingAgree())
-                .profileImgUrl(profileImgUrl)
-                .role(Role.HAIR_DESIGNER)
-                .build();
-        designerJpaRepository.save(designer);
-
+        designerJpaRepository.designerRegister(user.getId(), hairShop.getAddress(), hairShop.getDetailAddress(), hairShop.getName(), portfolio.getInstagramUrl(), portfolio.getNaverPlaceUrl(), request.introduction(), request.kakaoOpenChatUrl());
+        Designer designer = designerJpaRepository.findById(user.getId()).orElseThrow(() -> new NotFoundException(ErrorCode.DESIGNER_NOT_FOUND_EXCEPTION));
         request.dayOffs().stream()
                 .forEach(d -> {
                     DayOff dayOff = DayOff.builder()

--- a/src/main/java/com/moddy/server/service/designer/DesignerService.java
+++ b/src/main/java/com/moddy/server/service/designer/DesignerService.java
@@ -92,12 +92,7 @@ public class DesignerService {
 
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
 
-        user.setGender(request.gender());
-        user.setName(request.name());
-        user.setPhoneNumber(request.phoneNumber());
-        user.setIsMarketingAgree(request.isMarketingAgree());
-        user.setProfileImgUrl(profileImgUrl);
-        user.setRole(Role.HAIR_DESIGNER);
+        user.update(request.name(),request.gender(), request.phoneNumber(), request.isMarketingAgree(), profileImgUrl, Role.HAIR_DESIGNER);
 
         HairShop hairShop = HairShop.builder()
                 .name(request.hairShop().name())


### PR DESCRIPTION
## 관련 이슈번호
* Closes #118 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 1~2h

## 해결하려는 문제가 무엇인가요?
* userId 가 있는 designer 테이블에 값 업데이트

## 어떻게 해결했나요?
* set 사용
* 샘플코드 사용
* desinger 회원가입 시 새로 생성 고치기
* 
Modifying 어노테이션과 JPA 캐싱: Modifying 어노테이션은 데이터베이스에 대한 변경작업(INSERT, UPDATE, DELETE)을 수행하는 JPQL(JPA Query Language) 또는 SQL 쿼리에 사용됩니다. JPA는 일반적으로 일련의 변경 사항을 영속성 컨텍스트(persistence context)에 캐싱하고, 트랜잭션이 완료될 때까지 실제 데이터베이스에 반영하지 않습니다. 이 때문에, 데이터베이스 변경 후 즉시 새로운 데이터를 조회하려고 할 때 문제가 발생할 수 있습니다. 변경 작업 후에 영속성 컨텍스트가 아직 최신 상태로 업데이트되지 않았기 때문에, 새로운 데이터를 찾지 못할 수 있습니다.

clearAutomatically = true의 역할: Modifying(clearAutomatically = true)를 사용하면, 쿼리 실행 후 JPA의 영속성 컨텍스트를 자동으로 클리어합니다. 이는 변경 사항을 데이터베이스에 즉시 반영하고, 영속성 컨텍스트를 최신 상태로 갱신하는
효과가 있습니다. 

즉, clearAutomatically = true 옵션은 변경된 데이터가 데이터베이스에 반영된 직후에 영속성 컨텍스트를 초기화하여 변경 사항을 반영합니다. 이로 인해 이후에 수행되는 조회 작업에서 최신 데이터를 정확히 가져올 수 있게 됩니다.