### PR TITLE
#122 [feat] 디자이너 상세 보기 API, 머리 기장 상수 변환하는 과정 추가 

### DIFF
--- a/src/main/java/com/moddy/server/controller/designer/dto/response/ApplicationInfoResponse.java
+++ b/src/main/java/com/moddy/server/controller/designer/dto/response/ApplicationInfoResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record ApplicationInfoResponse(
         Long applicationId,
         String modelImgUrl,
-        HairLength hairLength,
+        String hairLength,
         List<String> preferHairstyles,
         List<HairRecordResponse> hairServiceRecords,
         String hairDetail,

--- a/src/main/java/com/moddy/server/service/designer/DesignerService.java
+++ b/src/main/java/com/moddy/server/service/designer/DesignerService.java
@@ -224,7 +224,7 @@ public class DesignerService {
         ApplicationInfoResponse applicationInfoResponse = new ApplicationInfoResponse(
                 applicationId,
                 hairModelApplication.getModelImgUrl(),
-                hairModelApplication.getHairLength(),
+                hairModelApplication.getHairLength().getValue(),
                 preferhairStyleList,
                 recordResponseList,
                 hairModelApplication.getHairDetail(),


### PR DESCRIPTION
## 관련 이슈번호
* Closes #122 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 10m / 10m

## 해결하려는 문제가 무엇인가요?
* 디자이너 상세 보기 API 반환 값 중 머리 기장을 나타내는 상수를 반환할 때, 상수의 value 값이 반환하는 것이 아닌 상수를 반환하고 있음

## 어떻게 해결했나요?
* reponse dto의 hair length type을 string 으로 바꾼 후, HairLength enum 값을 getValue를 추가했다