### PR TITLE
#168 [fix] instagramId 공백 허용 정규식 변경

### DIFF
--- a/src/main/java/com/moddy/server/controller/model/dto/request/ModelApplicationRequest.java
+++ b/src/main/java/com/moddy/server/controller/model/dto/request/ModelApplicationRequest.java
@@ -26,7 +26,7 @@ public record ModelApplicationRequest(
         @Size(min = 0, max = 3, message = "hairServiceRecord는 선택사항이며, 3개까지 추가 가능합니다.")
         List<ModelHairServiceRequest> hairServiceRecords,
         @Schema(description = "모델의 인스타그램 예시입니다.", example ="hizo0")
-        @Pattern(regexp = "^[^@\\s]*[_\\.]*[^\\s]+$", message = "인스타 그램 아이디에는 @는 들어올 수 없지만 _와 .는 가능합니다.")
+        @Pattern(regexp = "^([^@\\s]*[_\\.]*[^\\s]*)?$", message = "인스타 그램 아이디에는 @는 들어올 수 없지만 _와 .는 가능합니다.")
         String instagramId
 ) {
     public List<ModelHairServiceRequest> getHairServiceRecords() {


### PR DESCRIPTION
## 관련 이슈번호
* Closes #168 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 30m/10m

## 해결하려는 문제가 무엇인가요?
* 지원서 작성 시 인스타 그램 공백 허용 정규식 변경

## 어떻게 해결했나요?

<img width="412" alt="스크린샷 2024-01-18 오후 3 44 06" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/b2941e92-e3ce-4f56-a0a3-8ca021034f9f">
