### PR TITLE
#171 [fix] 카카오톡 오픈채팅방 링크 API, Application 조회시, offerID -> applicationID로 변경

### DIFF
--- a/src/main/java/com/moddy/server/service/model/ModelService.java
+++ b/src/main/java/com/moddy/server/service/model/ModelService.java
@@ -170,7 +170,7 @@ public class ModelService {
     public OpenChatResponse getOpenChatInfo(Long userId, Long offerId) {
 
         HairServiceOffer hairServiceOffer = hairServiceOfferJpaRepository.findById(offerId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUNT_OFFER_EXCEPTION));
-        HairModelApplication application = hairModelApplicationJpaRepository.findById(hairServiceOffer.getId()).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_APPLICATION_EXCEPTION));
+        HairModelApplication application = hairModelApplicationJpaRepository.findById(hairServiceOffer.getHairModelApplication().getId()).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_APPLICATION_EXCEPTION));
         Designer designer = designerJpaRepository.findById(hairServiceOffer.getDesigner().getId()).orElseThrow(() -> new NotFoundException(ErrorCode.DESIGNER_NOT_FOUND_EXCEPTION));
 
         DesignerInfoOpenChatResponse designerInfoOpenChatResponse = new DesignerInfoOpenChatResponse(designer.getProfileImgUrl(), designer.getHairShop().getName(), designer.getName(), designer.getIntroduction());


### PR DESCRIPTION
## 관련 이슈번호
* Closes #171

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 10m/10m

## 해결하려는 문제가 무엇인가요?
* 어플리케이션을 조회하는데 offerId로 조회를해서 ApplicationID로 변경했습니다~
