### PR TITLE
#193 [feat] 회원 탈퇴 시 이미지 삭제 로직 추가

### DIFF
--- a/src/main/java/com/moddy/server/external/s3/S3Service.java
+++ b/src/main/java/com/moddy/server/external/s3/S3Service.java
@@ -26,6 +26,7 @@ public class S3Service {
     private final static String APPLICATION_PATH = "APPLICATION";
     private final static String MODEL_PROFILE_PATH = "HAIR_MODEL_PROFILE";
     private final static String MODEL_PROFILE_IMAGE_NAME = "/model_default_profile.png";
+    private final static int IMAGE_URL_PREFIX_LENGTH = 54;
     private final static int EXPIRED_TIME = 3;
     private final AmazonS3 amazonS3;
     @Value("${cloud.aws.s3.bucket}")
@@ -44,6 +45,17 @@ public class S3Service {
         return amazonS3.getUrl(bucket, MODEL_PROFILE_PATH + MODEL_PROFILE_IMAGE_NAME).toString();
     }
 
+    public String getPreSignedUrlToDownload(final String fileName) {
+        final String imageKey = getImageUrlToKey(fileName);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, imageKey)
+                .withMethod(GET)
+                .withExpiration(getExpiredTime())
+                .withResponseHeaders(new ResponseHeaderOverrides().withContentDisposition("attachment"));
+
+        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+    }
+
     private String uploadImage(MultipartFile multipartFile, String path) {
         String fileName = createFileName(multipartFile.getOriginalFilename());
         ObjectMetadata objectMetadata = new ObjectMetadata();
@@ -58,13 +70,8 @@ public class S3Service {
         }
     }
 
-    public String getPreSignedUrlToDownload(final String fileName) {
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, fileName)
-                .withMethod(GET)
-                .withExpiration(getExpiredTime())
-                .withResponseHeaders(new ResponseHeaderOverrides().withContentDisposition("attachment"));
-
-        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+    private String getImageUrlToKey(final String imageUrl) {
+        return imageUrl.substring(IMAGE_URL_PREFIX_LENGTH);
     }
 
     private Date getExpiredTime() {

--- a/src/main/java/com/moddy/server/external/s3/S3Service.java
+++ b/src/main/java/com/moddy/server/external/s3/S3Service.java
@@ -56,6 +56,11 @@ public class S3Service {
         return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
     }
 
+    public void deleteS3Image(final String imageUrl) {
+        final String imageKey = getImageUrlToKey(imageUrl);
+        amazonS3.deleteObject(bucket, imageKey);
+    }
+
     private String uploadImage(MultipartFile multipartFile, String path) {
         String fileName = createFileName(multipartFile.getOriginalFilename());
         ObjectMetadata objectMetadata = new ObjectMetadata();

--- a/src/main/java/com/moddy/server/service/designer/DesignerService.java
+++ b/src/main/java/com/moddy/server/service/designer/DesignerService.java
@@ -256,9 +256,8 @@ public class DesignerService {
     }
 
     public DownloadUrlResponseDto getOfferImageDownloadUrl(final Long userId, final String offerImageUrl) {
-        //Designer designer = designerJpaRepository.findById(userId).orElseThrow(() -> new NotFoundException(DESIGNER_NOT_FOUND_EXCEPTION));
-        String s3Key = offerImageUrl.substring(54);
-        String preSignedUrl = s3Service.getPreSignedUrlToDownload(s3Key);
+        Designer designer = designerJpaRepository.findById(userId).orElseThrow(() -> new NotFoundException(DESIGNER_NOT_FOUND_EXCEPTION));
+        String preSignedUrl = s3Service.getPreSignedUrlToDownload(offerImageUrl);
         return new DownloadUrlResponseDto(preSignedUrl);
     }
 }

--- a/src/main/java/com/moddy/server/service/user/UserService.java
+++ b/src/main/java/com/moddy/server/service/user/UserService.java
@@ -63,10 +63,16 @@ public class UserService {
     private void deleteModelApplications(Long userId) {
         List<HairModelApplication> hairModelApplications = hairModelApplicationJpaRepository.findAllByModelId(userId);
         hairModelApplications.forEach(hairModelApplication -> {
+            deleteApplicationImage(hairModelApplication);
             preferHairStyleJpaRepository.deleteAllByHairModelApplication(hairModelApplication);
             hairServiceRecordJpaRepository.deleteAllByHairModelApplication(hairModelApplication);
             hairModelApplicationJpaRepository.deleteById(hairModelApplication.getId());
         });
+    }
+
+    private void deleteApplicationImage(final HairModelApplication hairModelApplication) {
+        s3Service.deleteS3Image(hairModelApplication.getApplicationCaptureUrl());
+        s3Service.deleteS3Image(hairModelApplication.getModelImgUrl());
     }
 
     private void deleteModelPreferRegions(Long userId) {


### PR DESCRIPTION
## 관련 이슈번호
* Closes #193 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 1h / 1h

## 해결하려는 문제가 무엇인가요?
* 회원 탈퇴 시 이미지는 삭제가 되지 않아서 s3 용량을 차지하는 이슈

## 어떻게 해결했나요?
* 유저 탈퇴시
  * 유저의 프로필 이미지는 default 값이므로 삭제하지 않고, 지원서의 캡처 이미지, 모델 이미지를 삭제했습니다.

* 디자이너 탈퇴 시
  * 디자이너 탈퇴 시 디자이너의 프로필을 삭제했습니다.

## 로직 수정 사항
* 데이터베이스에는 image url 형식으로 저장되어 있지만 이미지를 삭제하기 위해선 url의 앞부분은 잘라서 image key만 남겨야 합니다.
그래서 substring 하는 로직이 delete 할 때도 중복되어서 해당 로직을 s3 service 내로 이동했습니다.