### PR TITLE
#200 [refactor] 마이페이지 유저 정보 api 분리

### DIFF
--- a/src/main/java/com/moddy/server/controller/user/UserController.java
+++ b/src/main/java/com/moddy/server/controller/user/UserController.java
@@ -2,9 +2,7 @@ package com.moddy.server.controller.user;
 
 import com.moddy.server.common.dto.ErrorResponse;
 import com.moddy.server.common.dto.SuccessNonDataResponse;
-import com.moddy.server.common.dto.SuccessResponse;
 import com.moddy.server.config.resolver.user.UserId;
-import com.moddy.server.controller.user.dto.response.UserDetailResponseDto;
 import com.moddy.server.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,11 +14,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.moddy.server.common.exception.enums.SuccessCode.USER_MY_PAGE_SUCCESS;
 import static com.moddy.server.common.exception.enums.SuccessCode.USER_WITHDRAW_SUCCESS;
 
 @Tag(name = "User Controller", description = "유저 정보 조회 및 탈퇴 API 입니다.")
@@ -29,19 +25,6 @@ import static com.moddy.server.common.exception.enums.SuccessCode.USER_WITHDRAW_
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
-
-    @GetMapping
-    @Operation(summary = "[JWT] 유저 마이페이지 조회 API")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "마이페이지 유저 정보 조회 성공입니다."),
-            @ApiResponse(responseCode = "401", description = "토큰이 만료되었습니다. 다시 로그인 해주세요.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "해당 유저는 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @SecurityRequirement(name = "JWT Auth")
-    public SuccessResponse<UserDetailResponseDto> getUserDetail(@Parameter(hidden = true) @UserId Long userId) {
-        return SuccessResponse.success(USER_MY_PAGE_SUCCESS, userService.getUserDetail(userId));
-    }
 
     @DeleteMapping
     @Operation(summary = "[JWT] 유저 마이페이지 조회 API")

--- a/src/main/java/com/moddy/server/controller/user/UserRetrieveController.java
+++ b/src/main/java/com/moddy/server/controller/user/UserRetrieveController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +22,7 @@ import static com.moddy.server.common.exception.enums.SuccessCode.USER_MY_PAGE_S
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "User Controller", description = "유저 정보 조회 및 탈퇴 API 입니다.")
 @RequestMapping("/user")
 public class UserRetrieveController {
     private final UserRetrieveService userRetrieveService;

--- a/src/main/java/com/moddy/server/controller/user/UserRetrieveController.java
+++ b/src/main/java/com/moddy/server/controller/user/UserRetrieveController.java
@@ -1,11 +1,40 @@
 package com.moddy.server.controller.user;
 
+import com.moddy.server.common.dto.ErrorResponse;
+import com.moddy.server.common.dto.SuccessResponse;
+import com.moddy.server.config.resolver.user.UserId;
+import com.moddy.server.controller.user.dto.response.UserDetailResponseDto;
+import com.moddy.server.service.user.UserRetrieveService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.moddy.server.common.exception.enums.SuccessCode.USER_MY_PAGE_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
 public class UserRetrieveController {
+    private final UserRetrieveService userRetrieveService;
+
+    @GetMapping
+    @Operation(summary = "[JWT] 유저 마이페이지 조회 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "마이페이지 유저 정보 조회 성공입니다."),
+            @ApiResponse(responseCode = "401", description = "토큰이 만료되었습니다. 다시 로그인 해주세요.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 유저는 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirement(name = "JWT Auth")
+    public SuccessResponse<UserDetailResponseDto> getUserDetail(@Parameter(hidden = true) @UserId final Long userId) {
+        return SuccessResponse.success(USER_MY_PAGE_SUCCESS, userRetrieveService.getUserDetail(userId));
+    }
 }

--- a/src/main/java/com/moddy/server/service/user/UserRetrieveService.java
+++ b/src/main/java/com/moddy/server/service/user/UserRetrieveService.java
@@ -1,9 +1,21 @@
 package com.moddy.server.service.user;
 
+import com.moddy.server.common.exception.model.NotFoundException;
+import com.moddy.server.controller.user.dto.response.UserDetailResponseDto;
+import com.moddy.server.domain.user.User;
+import com.moddy.server.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static com.moddy.server.common.exception.enums.ErrorCode.USER_NOT_FOUND_EXCEPTION;
 
 @Service
 @RequiredArgsConstructor
 public class UserRetrieveService {
+    private final UserRepository userRepository;
+
+    public UserDetailResponseDto getUserDetail(final Long userId) {
+        final User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_EXCEPTION));
+        return new UserDetailResponseDto(user.getId(), user.getProfileImgUrl(), user.getName(), user.getRole());
+    }
 }

--- a/src/main/java/com/moddy/server/service/user/UserService.java
+++ b/src/main/java/com/moddy/server/service/user/UserService.java
@@ -40,11 +40,6 @@ public class UserService {
     private final DesignerJpaRepository designerJpaRepository;
     private final S3Service s3Service;
 
-    public UserDetailResponseDto getUserDetail(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_EXCEPTION));
-        return new UserDetailResponseDto(user.getId(), user.getProfileImgUrl(), user.getName(), user.getRole());
-    }
-
     private void deleteModelInfos(Long userId) {
         deleteModelHairServiceOfferInfos(userId);
         deleteModelApplications(userId);


### PR DESCRIPTION
## 관련 이슈번호
* Closes #200 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 30m

## 해결하려는 문제가 무엇인가요?
* 조회 api 컨트롤러 및 서비스 분리

## 어떻게 해결했나요?
* 조회 api 로직을 조회 컨트롤러, 서비스로 이전했습니다.
* 컨트롤러 분리를 할 때 `@Tag` 어노테이션을 조회 컨트롤러와 저장 컨트롤러를 동일하게 해야합니다!
그렇지 않으면 스웨거에서 2개의 컨트롤러로 쪼개집니다..! 
`@Tag` 를 동일하게 달아주면, 2개의 컨트롤러지만 스웨거에서 하나의 컨트롤러로 볼 수 있습니다!