### PR TITLE
#202 [refactor] 유저 탈퇴 로직 서비스 분리

### DIFF
--- a/src/main/java/com/moddy/server/controller/user/UserController.java
+++ b/src/main/java/com/moddy/server/controller/user/UserController.java
@@ -42,18 +42,4 @@ public class UserController {
     public SuccessResponse<UserDetailResponseDto> getUserDetail(@Parameter(hidden = true) @UserId Long userId) {
         return SuccessResponse.success(USER_MY_PAGE_SUCCESS, userService.getUserDetail(userId));
     }
-
-    @DeleteMapping
-    @Operation(summary = "[JWT] 유저 마이페이지 조회 API")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공입니다."),
-            @ApiResponse(responseCode = "401", description = "토큰이 만료되었습니다. 다시 로그인 해주세요.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "해당 유저는 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @SecurityRequirement(name = "JWT Auth")
-    public SuccessNonDataResponse withdraw(@Parameter(hidden = true) @UserId Long userId) {
-        userService.withdraw(userId);
-        return SuccessNonDataResponse.success(USER_WITHDRAW_SUCCESS);
-    }
 }

--- a/src/main/java/com/moddy/server/controller/user/UserRegisterController.java
+++ b/src/main/java/com/moddy/server/controller/user/UserRegisterController.java
@@ -1,11 +1,42 @@
 package com.moddy.server.controller.user;
 
+import com.moddy.server.common.dto.ErrorResponse;
+import com.moddy.server.common.dto.SuccessNonDataResponse;
+import com.moddy.server.config.resolver.user.UserId;
+import com.moddy.server.service.user.UserRegisterService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.moddy.server.common.exception.enums.SuccessCode.USER_WITHDRAW_SUCCESS;
+
+@Tag(name = "User Controller", description = "유저 정보 조회 및 탈퇴 API 입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
 public class UserRegisterController {
+    private final UserRegisterService userRegisterService;
+
+    @DeleteMapping
+    @Operation(summary = "[JWT] 유저 탈퇴하기 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공입니다."),
+            @ApiResponse(responseCode = "401", description = "토큰이 만료되었습니다. 다시 로그인 해주세요.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 유저는 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirement(name = "JWT Auth")
+    public SuccessNonDataResponse withdraw(@Parameter(hidden = true) @UserId final Long userId) {
+        userRegisterService.withdraw(userId);
+        return SuccessNonDataResponse.success(USER_WITHDRAW_SUCCESS);
+    }
 }

--- a/src/main/java/com/moddy/server/service/application/HairModelApplicationRegisterService.java
+++ b/src/main/java/com/moddy/server/service/application/HairModelApplicationRegisterService.java
@@ -1,0 +1,35 @@
+package com.moddy.server.service.application;
+
+import com.moddy.server.domain.hair_model_application.HairModelApplication;
+import com.moddy.server.domain.hair_model_application.repository.HairModelApplicationJpaRepository;
+import com.moddy.server.domain.hair_service_record.repository.HairServiceRecordJpaRepository;
+import com.moddy.server.domain.prefer_hair_style.repository.PreferHairStyleJpaRepository;
+import com.moddy.server.external.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HairModelApplicationRegisterService {
+    private final S3Service s3Service;
+    private final HairModelApplicationJpaRepository hairModelApplicationJpaRepository;
+    private final PreferHairStyleJpaRepository preferHairStyleJpaRepository;
+    private final HairServiceRecordJpaRepository hairServiceRecordJpaRepository;
+
+    public void deleteModelApplications(final Long modelId) {
+        List<HairModelApplication> hairModelApplications = hairModelApplicationJpaRepository.findAllByModelId(modelId);
+        hairModelApplications.forEach(hairModelApplication -> {
+            deleteApplicationImage(hairModelApplication);
+            preferHairStyleJpaRepository.deleteAllByHairModelApplication(hairModelApplication);
+            hairServiceRecordJpaRepository.deleteAllByHairModelApplication(hairModelApplication);
+            hairModelApplicationJpaRepository.deleteById(hairModelApplication.getId());
+        });
+    }
+
+    private void deleteApplicationImage(final HairModelApplication hairModelApplication) {
+        s3Service.deleteS3Image(hairModelApplication.getApplicationCaptureUrl());
+        s3Service.deleteS3Image(hairModelApplication.getModelImgUrl());
+    }
+}

--- a/src/main/java/com/moddy/server/service/designer/DesignerRegisterService.java
+++ b/src/main/java/com/moddy/server/service/designer/DesignerRegisterService.java
@@ -1,0 +1,22 @@
+package com.moddy.server.service.designer;
+
+import com.moddy.server.domain.day_off.repository.DayOffJpaRepository;
+import com.moddy.server.domain.designer.repository.DesignerJpaRepository;
+import com.moddy.server.domain.user.User;
+import com.moddy.server.external.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DesignerRegisterService {
+    private final DesignerJpaRepository designerJpaRepository;
+    private final DayOffJpaRepository dayOffJpaRepository;
+    private final S3Service s3Service;
+
+    public void deleteDesignerInfo(final User designer) {
+        dayOffJpaRepository.deleteAllByDesignerId(designer.getId());
+        s3Service.deleteS3Image(designer.getProfileImgUrl());
+        designerJpaRepository.deleteById(designer.getId());
+    }
+}

--- a/src/main/java/com/moddy/server/service/model/ModelRegisterService.java
+++ b/src/main/java/com/moddy/server/service/model/ModelRegisterService.java
@@ -1,0 +1,22 @@
+package com.moddy.server.service.model;
+
+import com.moddy.server.domain.model.repository.ModelJpaRepository;
+import com.moddy.server.domain.prefer_region.repository.PreferRegionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ModelRegisterService {
+    private final PreferRegionJpaRepository preferRegionJpaRepository;
+    private final ModelJpaRepository modelJpaRepository;
+
+    public void deleteModelInfo(final Long modelId) {
+        modelJpaRepository.deleteById(modelId);
+        deleteModelPreferRegions(modelId);
+    }
+
+    private void deleteModelPreferRegions(final Long modelId) {
+        preferRegionJpaRepository.deleteAllByModelId(modelId);
+    }
+}

--- a/src/main/java/com/moddy/server/service/model/ModelRegisterService.java
+++ b/src/main/java/com/moddy/server/service/model/ModelRegisterService.java
@@ -12,8 +12,8 @@ public class ModelRegisterService {
     private final ModelJpaRepository modelJpaRepository;
 
     public void deleteModelInfo(final Long modelId) {
-        modelJpaRepository.deleteById(modelId);
         deleteModelPreferRegions(modelId);
+        modelJpaRepository.deleteById(modelId);
     }
 
     private void deleteModelPreferRegions(final Long modelId) {

--- a/src/main/java/com/moddy/server/service/offer/HairServiceOfferRegisterService.java
+++ b/src/main/java/com/moddy/server/service/offer/HairServiceOfferRegisterService.java
@@ -1,0 +1,24 @@
+package com.moddy.server.service.offer;
+
+import com.moddy.server.domain.hair_service_offer.HairServiceOffer;
+import com.moddy.server.domain.hair_service_offer.repository.HairServiceOfferJpaRepository;
+import com.moddy.server.domain.prefer_offer_condition.repository.PreferOfferConditionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HairServiceOfferRegisterService {
+    private final PreferOfferConditionJpaRepository preferOfferConditionJpaRepository;
+    private final HairServiceOfferJpaRepository hairServiceOfferJpaRepository;
+
+    public void deleteModelHairServiceOfferInfos(final Long modelId) {
+        final List<HairServiceOffer> hairServiceOffers = hairServiceOfferJpaRepository.findAllByModelId(modelId);
+        hairServiceOffers.forEach(hairServiceOffer -> {
+            preferOfferConditionJpaRepository.deleteAllByHairServiceOffer(hairServiceOffer);
+            hairServiceOfferJpaRepository.deleteById(hairServiceOffer.getId());
+        });
+    }
+}

--- a/src/main/java/com/moddy/server/service/offer/HairServiceOfferRegisterService.java
+++ b/src/main/java/com/moddy/server/service/offer/HairServiceOfferRegisterService.java
@@ -21,4 +21,12 @@ public class HairServiceOfferRegisterService {
             hairServiceOfferJpaRepository.deleteById(hairServiceOffer.getId());
         });
     }
+
+    public void deleteDesignerHairServiceOfferInfos(final Long designerId) {
+        final List<HairServiceOffer> hairServiceOffers = hairServiceOfferJpaRepository.findAllByDesignerId(designerId);
+        hairServiceOffers.forEach(hairServiceOffer -> {
+            preferOfferConditionJpaRepository.deleteAllByHairServiceOffer(hairServiceOffer);
+            hairServiceOfferJpaRepository.deleteById(hairServiceOffer.getId());
+        });
+    }
 }

--- a/src/main/java/com/moddy/server/service/user/UserRegisterService.java
+++ b/src/main/java/com/moddy/server/service/user/UserRegisterService.java
@@ -1,9 +1,36 @@
 package com.moddy.server.service.user;
 
+import com.moddy.server.common.exception.model.NotFoundException;
+import com.moddy.server.domain.user.User;
+import com.moddy.server.domain.user.repository.UserRepository;
+import com.moddy.server.service.application.HairModelApplicationRegisterService;
+import com.moddy.server.service.model.ModelRegisterService;
+import com.moddy.server.service.offer.HairServiceOfferRegisterService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static com.moddy.server.common.exception.enums.ErrorCode.USER_NOT_FOUND_EXCEPTION;
+import static com.moddy.server.domain.user.Role.MODEL;
 
 @Service
 @RequiredArgsConstructor
 public class UserRegisterService {
+    private final UserRepository userRepository;
+    private final HairServiceOfferRegisterService hairServiceOfferRegisterService;
+    private final HairModelApplicationRegisterService hairModelApplicationRegisterService;
+    private final ModelRegisterService modelRegisterService;
+
+    @Transactional
+    public void withdraw(final Long userId) {
+        final User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_EXCEPTION));
+        if (user.getRole() == MODEL) deleteModelInfos(userId);
+    }
+
+    private void deleteModelInfos(final Long modelId) {
+        hairServiceOfferRegisterService.deleteModelHairServiceOfferInfos(modelId);
+        hairModelApplicationRegisterService.deleteModelApplications(modelId);
+        modelRegisterService.deleteModelInfo(modelId);
+        userRepository.deleteById(modelId);
+    }
 }

--- a/src/main/java/com/moddy/server/service/user/UserRegisterService.java
+++ b/src/main/java/com/moddy/server/service/user/UserRegisterService.java
@@ -4,6 +4,7 @@ import com.moddy.server.common.exception.model.NotFoundException;
 import com.moddy.server.domain.user.User;
 import com.moddy.server.domain.user.repository.UserRepository;
 import com.moddy.server.service.application.HairModelApplicationRegisterService;
+import com.moddy.server.service.designer.DesignerRegisterService;
 import com.moddy.server.service.model.ModelRegisterService;
 import com.moddy.server.service.offer.HairServiceOfferRegisterService;
 import jakarta.transaction.Transactional;
@@ -20,11 +21,13 @@ public class UserRegisterService {
     private final HairServiceOfferRegisterService hairServiceOfferRegisterService;
     private final HairModelApplicationRegisterService hairModelApplicationRegisterService;
     private final ModelRegisterService modelRegisterService;
+    private final DesignerRegisterService designerRegisterService;
 
     @Transactional
     public void withdraw(final Long userId) {
         final User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_EXCEPTION));
         if (user.getRole() == MODEL) deleteModelInfos(userId);
+        else deleteDesignerInfos(user);
     }
 
     private void deleteModelInfos(final Long modelId) {
@@ -32,5 +35,11 @@ public class UserRegisterService {
         hairModelApplicationRegisterService.deleteModelApplications(modelId);
         modelRegisterService.deleteModelInfo(modelId);
         userRepository.deleteById(modelId);
+    }
+
+    private void deleteDesignerInfos(final User designer) {
+        hairServiceOfferRegisterService.deleteDesignerHairServiceOfferInfos(designer.getId());
+        designerRegisterService.deleteDesignerInfo(designer);
+        userRepository.deleteById(designer.getId());
     }
 }

--- a/src/main/java/com/moddy/server/service/user/UserService.java
+++ b/src/main/java/com/moddy/server/service/user/UserService.java
@@ -2,120 +2,20 @@ package com.moddy.server.service.user;
 
 import com.moddy.server.common.exception.model.NotFoundException;
 import com.moddy.server.controller.user.dto.response.UserDetailResponseDto;
-import com.moddy.server.domain.day_off.repository.DayOffJpaRepository;
-import com.moddy.server.domain.designer.repository.DesignerJpaRepository;
-import com.moddy.server.domain.hair_model_application.HairModelApplication;
-import com.moddy.server.domain.hair_model_application.repository.HairModelApplicationJpaRepository;
-import com.moddy.server.domain.hair_service_offer.HairServiceOffer;
-import com.moddy.server.domain.hair_service_offer.repository.HairServiceOfferJpaRepository;
-import com.moddy.server.domain.hair_service_record.repository.HairServiceRecordJpaRepository;
-import com.moddy.server.domain.model.repository.ModelJpaRepository;
-import com.moddy.server.domain.prefer_hair_style.repository.PreferHairStyleJpaRepository;
-import com.moddy.server.domain.prefer_offer_condition.repository.PreferOfferConditionJpaRepository;
-import com.moddy.server.domain.prefer_region.repository.PreferRegionJpaRepository;
 import com.moddy.server.domain.user.User;
 import com.moddy.server.domain.user.repository.UserRepository;
-import com.moddy.server.external.s3.S3Service;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 import static com.moddy.server.common.exception.enums.ErrorCode.USER_NOT_FOUND_EXCEPTION;
-import static com.moddy.server.domain.user.Role.MODEL;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
-    private final HairModelApplicationJpaRepository hairModelApplicationJpaRepository;
-    private final HairServiceOfferJpaRepository hairServiceOfferJpaRepository;
-    private final PreferOfferConditionJpaRepository preferOfferConditionJpaRepository;
-    private final PreferHairStyleJpaRepository preferHairStyleJpaRepository;
-    private final HairServiceRecordJpaRepository hairServiceRecordJpaRepository;
-    private final DayOffJpaRepository dayOffJpaRepository;
-    private final PreferRegionJpaRepository preferRegionJpaRepository;
-    private final ModelJpaRepository modelJpaRepository;
-    private final DesignerJpaRepository designerJpaRepository;
-    private final S3Service s3Service;
 
     public UserDetailResponseDto getUserDetail(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_EXCEPTION));
         return new UserDetailResponseDto(user.getId(), user.getProfileImgUrl(), user.getName(), user.getRole());
-    }
-
-    private void deleteModelInfos(Long userId) {
-        deleteModelHairServiceOfferInfos(userId);
-        deleteModelApplications(userId);
-        deleteModelPreferRegions(userId);
-        deleteModelInfo(userId);
-    }
-
-    private void deleteModelHairServiceOfferInfos(Long userId) {
-        List<HairServiceOffer> hairServiceOffers = hairServiceOfferJpaRepository.findAllByModelId(userId);
-        hairServiceOffers.forEach(hairServiceOffer -> {
-            preferOfferConditionJpaRepository.deleteAllByHairServiceOffer(hairServiceOffer);
-            hairServiceOfferJpaRepository.deleteById(hairServiceOffer.getId());
-        });
-    }
-
-    private void deleteModelApplications(Long userId) {
-        List<HairModelApplication> hairModelApplications = hairModelApplicationJpaRepository.findAllByModelId(userId);
-        hairModelApplications.forEach(hairModelApplication -> {
-            deleteApplicationImage(hairModelApplication);
-            preferHairStyleJpaRepository.deleteAllByHairModelApplication(hairModelApplication);
-            hairServiceRecordJpaRepository.deleteAllByHairModelApplication(hairModelApplication);
-            hairModelApplicationJpaRepository.deleteById(hairModelApplication.getId());
-        });
-    }
-
-    private void deleteApplicationImage(final HairModelApplication hairModelApplication) {
-        s3Service.deleteS3Image(hairModelApplication.getApplicationCaptureUrl());
-        s3Service.deleteS3Image(hairModelApplication.getModelImgUrl());
-    }
-
-    private void deleteModelPreferRegions(Long userId) {
-        preferRegionJpaRepository.deleteAllByModelId(userId);
-    }
-
-    private void deleteModelInfo(Long userId) {
-        modelJpaRepository.deleteById(userId);
-        userRepository.deleteById(userId);
-    }
-
-    private void deleteDesignerInfos(final User user) {
-        deleteDesignerHairServiceOfferInfos(user.getId());
-        deleteDesignerDayOffs(user.getId());
-        deleteDesignerProfileImage(user);
-        deleteDesignerInfo(user.getId());
-    }
-
-    private void deleteDesignerHairServiceOfferInfos(Long userId) {
-        List<HairServiceOffer> hairServiceOffers = hairServiceOfferJpaRepository.findAllByDesignerId(userId);
-        hairServiceOffers.forEach(hairServiceOffer -> {
-            preferOfferConditionJpaRepository.deleteAllByHairServiceOffer(hairServiceOffer);
-            hairServiceOfferJpaRepository.deleteById(hairServiceOffer.getId());
-        });
-    }
-
-    private void deleteDesignerDayOffs(Long userId) {
-        dayOffJpaRepository.deleteAllByDesignerId(userId);
-    }
-
-    private void deleteDesignerInfo(Long userId) {
-        designerJpaRepository.deleteById(userId);
-        userRepository.deleteById(userId);
-    }
-
-    private void deleteDesignerProfileImage(final User user) {
-        s3Service.deleteS3Image(user.getProfileImgUrl());
-    }
-
-    @Transactional
-    public void withdraw(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_EXCEPTION));
-        if (user.getRole() == MODEL) deleteModelInfos(userId);
-        else deleteDesignerInfos(user);
     }
 }


### PR DESCRIPTION
## 관련 이슈번호
* Closes #202 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 1h

## 해결하려는 문제가 무엇인가요?
* 유저 탈퇴 로직 서비스 별로 분리

## 어떻게 해결했나요?
* 각 탈퇴 로직을 서비스 별로 분리해서 삭제하도록 로직 수정했습니다.
* 삭제 로직을 구현하다 보니까 offer에 model 의존성을 없애면 로직이 되게 복잡해져서 offer 내부에 model 삭제는 미뤄야할 것 같습니다. cascade 공부해서 적용한 다음에 없애야 할 것 같습니다..!