### PR TITLE
#204 [feat] 배포 / 개발 서버 분리

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -3,8 +3,6 @@ name: MODDY DEV CD
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   deploy-ci:

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -3,6 +3,8 @@ name: MODDY DEV CD
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   deploy-ci:

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -1,0 +1,63 @@
+name: MODDY DEV CD
+
+on:
+  push:
+    branches: [ "develop" ]
+
+jobs:
+  deploy-ci:
+    runs-on: ubuntu-22.04
+    env:
+      working-directory: moddy-server
+
+    steps:
+      - name: 체크아웃
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+
+      - name: application.yml 생성
+        run: |
+          cd src/main/resources 
+          echo "${{ secrets.APPLICATION_DEVELOP }}" > ./application.yml
+
+      - name: 빌드
+        run: |
+          chmod +x gradlew
+          ./gradlew build -x test
+        shell: bash
+
+      ######## 여기까지는 CI.yml와 동일 #########
+
+      - name: docker build 가능하도록 환경 설정
+        uses: docker/setup-buildx-action@v2.9.1
+
+      - name: docker hub에로그인
+        uses: docker/login-action@v2.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LOGIN_ACCESSTOKEN }}
+
+      - name: docker image 빌드 및 푸시
+        run: |
+          docker build --platform linux/amd64 -t moddy1217/moddy-develop .
+          docker push moddy1217/moddy-develop
+
+  deploy-cd:
+    needs: deploy-ci
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: 도커 컨테이너 실행
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEVELOP_SERVER_IP }}
+          username: ${{ secrets.DEVELOP_SERVER_USER }}
+          key: ${{ secrets.DEVELOP_SERVER_KEY }}
+          script: |
+            cd ~
+            ./deploy.sh

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -1,0 +1,34 @@
+name: MODDY DEV CI
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      working-directory: moddy-server
+
+    steps:
+      - name: 체크아웃
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+
+      - name: application.yml 생성
+        run: |
+          cd src/main/resources 
+          echo "${{ secrets.APPLICATION_DEVELOP }}" > ./application.yml
+
+      - name: 빌드
+        run: |
+          chmod +x gradlew
+          ./gradlew build -x test
+        shell: bash

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -3,8 +3,8 @@ name: MODDY DEV CI
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
+#  pull_request:
+#    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -3,8 +3,8 @@ name: MODDY DEV CI
 on:
   push:
     branches: [ "develop" ]
-#  pull_request:
-#    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/pord-cd.yml
+++ b/.github/workflows/pord-cd.yml
@@ -1,8 +1,8 @@
-name: MODDY DEV CD
+name: MODDY PROD CD
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
 
 jobs:
   deploy-ci:

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -1,10 +1,10 @@
-name: MODDY DEV CI
+name: MODDY PROD CI
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
   pull_request: 
-    branches: [ "develop" ]
+    branches: [ "main" ]
 
 jobs:
   build: 


### PR DESCRIPTION
## 관련 이슈번호
* Closes #204 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 2h / 진행 중

## 해결하려는 문제가 무엇인가요?
* 배포 / 개발 서버 분리

## 어떻게 해결했나요?
* github actions : dev 용 secrets 추가함
* aws : dev 용 ec2, rds, s3 추가 및 탄력적 ip 적용
* dev용 https 배포 완
* 배포용 계정에 dev 용 docker repository 추가로 생성
* 개발 서버에서 500 에러 발생 시, 디스코드 알림 오는 채널 따로 만들었습니다
* ci / cd 적용
* develop <- 개발용 서버 ci / cd 
* main <- 배포용 서버 ci / cd

## 수정 사항
- 노션 private 페이지가서 본인의 로컬 application.yml 파일에서 s3 정보를 개발용 s3 경로로 수정해주세요!
배포용 s3에 개발할 때 테스트 용도로 추가하는 이미지를 분리하기 위함