### PR TITLE
#198 [Refactor] 모델 회원가입 API Service 분리 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	implementation 'com.squareup.okhttp3:okhttp:4.9.3'

--- a/src/main/java/com/moddy/server/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/moddy/server/common/exception/enums/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
 
     // 409 Conflict
     ALREADY_EXIST_USER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 유저입니다."),
+    ALREADY_EXIST_MODEL_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 모델입니다."),
     ALREADY_EXIST_OFFER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 제안서입니다"),
 
     // 500

--- a/src/main/java/com/moddy/server/controller/auth/AuthController.java
+++ b/src/main/java/com/moddy/server/controller/auth/AuthController.java
@@ -5,7 +5,6 @@ import com.moddy.server.common.dto.ErrorResponse;
 import com.moddy.server.common.dto.SuccessNonDataResponse;
 import com.moddy.server.common.dto.SuccessResponse;
 import com.moddy.server.common.exception.enums.SuccessCode;
-import com.moddy.server.common.util.SmsUtil;
 import com.moddy.server.config.resolver.kakao.KakaoCode;
 import com.moddy.server.config.resolver.user.UserId;
 import com.moddy.server.controller.auth.dto.request.PhoneNumberRequestDto;
@@ -14,10 +13,8 @@ import com.moddy.server.controller.auth.dto.response.LoginResponseDto;
 import com.moddy.server.controller.auth.dto.response.RegionResponse;
 import com.moddy.server.controller.designer.dto.request.DesignerCreateRequest;
 import com.moddy.server.controller.designer.dto.response.UserCreateResponse;
-import com.moddy.server.controller.model.dto.request.ModelCreateRequest;
 import com.moddy.server.service.auth.AuthService;
 import com.moddy.server.service.designer.DesignerService;
-import com.moddy.server.service.model.ModelService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -55,8 +52,6 @@ public class AuthController {
     private static final String ORIGIN = "origin";
     private final AuthService authService;
     private final DesignerService designerService;
-    private final ModelService modelService;
-    private final SmsUtil smsUtil;
 
     @Operation(summary = "[KAKAO CODE] 로그인 API")
     @ApiResponses(value = {
@@ -95,21 +90,6 @@ public class AuthController {
             @RequestPart(value = "profileImg", required = false) MultipartFile profileImg,
             @Valid @RequestPart("designerInfo") DesignerCreateRequest designerInfo) {
         return SuccessResponse.success(SuccessCode.DESIGNER_CREATE_SUCCESS, designerService.createDesigner(userId, designerInfo, profileImg));
-    }
-
-    @Operation(summary = "[JWT] 모델 회원가입 API", description = "모델 회원가입 API입니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "모델 회원가입 성공"),
-            @ApiResponse(responseCode = "401", description = "인증오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "유효하지 않은 값을 입력했습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @PostMapping(value = "/signup/model")
-    @SecurityRequirement(name = "JWT Auth")
-    public SuccessResponse<UserCreateResponse> createModel(
-            @Parameter(hidden = true) @UserId Long userId,
-            @Valid @RequestBody ModelCreateRequest modelCreateRequest) {
-        return SuccessResponse.success(SuccessCode.MODEL_CREATE_SUCCESS, modelService.createModel(userId, modelCreateRequest));
     }
 
     @Operation(summary = "인증번호 요청 API", description = "인증번호 요청 API입니다.")

--- a/src/main/java/com/moddy/server/controller/model/ModelController.java
+++ b/src/main/java/com/moddy/server/controller/model/ModelController.java
@@ -36,7 +36,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@Tag(name = "ModelController")
 @RequiredArgsConstructor
 public class ModelController {
 
@@ -59,6 +58,7 @@ public class ModelController {
         return SuccessResponse.success(SuccessCode.MODEL_CREATE_SUCCESS, modelRegisterService.createModel(userId, modelCreateRequest));
     }
 
+    @Tag(name = "ModelController")
     @Operation(summary = "[JWT] 모델 메인 뷰 조회", description = "모델 메인 뷰 조회 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "모델 메인뷰 조회 성공", content = @Content(schema = @Schema(implementation = ModelMainResponse.class))),
@@ -74,6 +74,7 @@ public class ModelController {
         return SuccessResponse.success(SuccessCode.FIND_MODEL_MAIN_INFO_SUCCESS, modelService.getModelMainInfo(userId, page, size));
     }
 
+    @Tag(name = "ModelController")
     @Operation(summary = "[JWT] 제안서 상세보기 뷰 조회", description = "제안서 상세보기 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "제안서 상세보기 조회 성공", content = @Content(schema = @Schema(implementation = DetailOfferResponse.class))),
@@ -89,6 +90,7 @@ public class ModelController {
         return SuccessResponse.success(SuccessCode.FIND_MODEL_DETAIL_OFFER_SUCCESS, modelService.getOfferDetail(userId, offerId));
     }
 
+    @Tag(name = "ModelController")
     @Operation(summary = "[JWT] 카카오톡 오픈채팅", description = "지원서 캡처 이미지 및 디자이너 정보 조회입니다")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "모델 메인뷰 조회 성공", content = @Content(schema = @Schema(implementation = OpenChatResponse.class))),
@@ -103,6 +105,7 @@ public class ModelController {
         return SuccessResponse.success(SuccessCode.OPEN_CHAT_GET_SUCCESS, modelService.getOpenChatInfo(userId, offerId));
     }
 
+    @Tag(name = "ModelController")
     @Operation(summary = "[JWT] 디자이너 제안서 승낙하기", description = "디자이너 제안서 승낙하기 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "디자이너 제안서 승낙하기"),
@@ -119,6 +122,7 @@ public class ModelController {
         return SuccessNonDataResponse.success(SuccessCode.OFFER_ACCEPT_SUCCESS);
     }
 
+    @Tag(name = "ModelController")
     @Operation(summary = "[JWT] 모델 지원서 작성", description = "모델 지원서 작성 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "모델 지원서 작성 성공"),
@@ -136,6 +140,7 @@ public class ModelController {
         return SuccessNonDataResponse.success(SuccessCode.CREATE_MODEL_APPLICATION_SUCCESS);
     }
 
+    @Tag(name = "ModelController")
     @Operation(summary = "[JWT] 모델 지원서 최종 확인 시 유저 정보 조회 API", description = "[모델 뷰] 모델 지원서 최종 확인 시 유저 정보 조회 API 입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "모델 지원서 작성 성공"),

--- a/src/main/java/com/moddy/server/controller/model/ModelController.java
+++ b/src/main/java/com/moddy/server/controller/model/ModelController.java
@@ -5,11 +5,14 @@ import com.moddy.server.common.dto.SuccessNonDataResponse;
 import com.moddy.server.common.dto.SuccessResponse;
 import com.moddy.server.common.exception.enums.SuccessCode;
 import com.moddy.server.config.resolver.user.UserId;
+import com.moddy.server.controller.designer.dto.response.UserCreateResponse;
 import com.moddy.server.controller.model.dto.request.ModelApplicationRequest;
+import com.moddy.server.controller.model.dto.request.ModelCreateRequest;
 import com.moddy.server.controller.model.dto.response.ApplicationUserDetailResponse;
 import com.moddy.server.controller.model.dto.response.DetailOfferResponse;
 import com.moddy.server.controller.model.dto.response.ModelMainResponse;
 import com.moddy.server.controller.model.dto.response.OpenChatResponse;
+import com.moddy.server.service.model.ModelRegisterService;
 import com.moddy.server.service.model.ModelService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,7 +29,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,11 +37,27 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @Tag(name = "ModelController")
-@RequestMapping("/model")
 @RequiredArgsConstructor
 public class ModelController {
 
     private final ModelService modelService;
+    private final ModelRegisterService modelRegisterService;
+
+    @Tag(name = "Auth Controller", description = "로그인 및 회원 가입 관련 API 입니다.")
+    @Operation(summary = "[JWT] 모델 회원가입 API", description = "모델 회원가입 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "모델 회원가입 성공"),
+            @ApiResponse(responseCode = "401", description = "인증오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "유효하지 않은 값을 입력했습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping(value = "/auth/signup/model")
+    @SecurityRequirement(name = "JWT Auth")
+    public SuccessResponse<UserCreateResponse> createModel(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Valid @RequestBody ModelCreateRequest modelCreateRequest) {
+        return SuccessResponse.success(SuccessCode.MODEL_CREATE_SUCCESS, modelRegisterService.createModel(userId, modelCreateRequest));
+    }
 
     @Operation(summary = "[JWT] 모델 메인 뷰 조회", description = "모델 메인 뷰 조회 API입니다.")
     @ApiResponses({
@@ -46,7 +65,7 @@ public class ModelController {
             @ApiResponse(responseCode = "401", description = "인증 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
-    @GetMapping
+    @GetMapping("/model")
     @SecurityRequirement(name = "JWT Auth")
     public SuccessResponse<ModelMainResponse> getModelMainInfo(
             @Parameter(hidden = true) @UserId Long userId,
@@ -62,7 +81,7 @@ public class ModelController {
             @ApiResponse(responseCode = "404", description = "제안서 아이디가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
-    @GetMapping("/offer/{offerId}")
+    @GetMapping("/model/offer/{offerId}")
     @SecurityRequirement(name = "JWT Auth")
     public SuccessResponse<DetailOfferResponse> getModelDetailOfferInfo(
             @Parameter(hidden = true) @UserId Long userId,
@@ -76,7 +95,7 @@ public class ModelController {
             @ApiResponse(responseCode = "401", description = "인증 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
-    @GetMapping("/{offerId}/agree")
+    @GetMapping("/model/{offerId}/agree")
     @SecurityRequirement(name = "JWT Auth")
     public SuccessResponse<OpenChatResponse> getOpenChat(
             @Parameter(hidden = true) @UserId Long userId,
@@ -91,7 +110,7 @@ public class ModelController {
             @ApiResponse(responseCode = "404", description = "제안서 아이디가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
-    @PutMapping("/offer/{offerId}")
+    @PutMapping("/model/offer/{offerId}")
     @SecurityRequirement(name = "JWT Auth")
     public SuccessNonDataResponse acceptOffer(
             @Parameter(hidden = true) @UserId Long userId,
@@ -107,7 +126,7 @@ public class ModelController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @SecurityRequirement(name = "JWT Auth")
-    @PostMapping(value = "/application", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/model/application", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public SuccessNonDataResponse submitModelApplication(
             @Parameter(hidden = true) @UserId Long userId,
             @RequestPart(value = "modelImgUrl", required = false) MultipartFile modelImgUrl,
@@ -125,7 +144,7 @@ public class ModelController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @SecurityRequirement(name = "JWT Auth")
-    @GetMapping(value = "/application/user")
+    @GetMapping(value = "/model/application/user")
     public SuccessResponse<ApplicationUserDetailResponse> getUserDetailInApplication(@Parameter(hidden = true) @UserId Long userId) {
         return SuccessResponse.success(SuccessCode.CREATE_MODEL_APPLICATION_SUCCESS, modelService.getUserDetailInApplication(userId));
     }

--- a/src/main/java/com/moddy/server/controller/model/dto/request/ModelCreateRequest.java
+++ b/src/main/java/com/moddy/server/controller/model/dto/request/ModelCreateRequest.java
@@ -2,6 +2,7 @@ package com.moddy.server.controller.model.dto.request;
 
 import com.moddy.server.common.validation.year.ValidYear;
 import com.moddy.server.common.validation.prefer_regions.ValidPreferRegions;
+import com.moddy.server.controller.user.dto.UserUpdateDto;
 import com.moddy.server.domain.user.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
@@ -35,4 +36,13 @@ public record ModelCreateRequest(
         @ValidPreferRegions
         List<Long> preferRegions
 ) {
+        public UserUpdateDto userInfoUpdate() {
+                return new UserUpdateDto(
+                        this.name(),
+                        this.gender(),
+                        this.phoneNumber(),
+                        this.isMarketingAgree()
+                );
+        }
+
 }

--- a/src/main/java/com/moddy/server/controller/user/dto/UserUpdateDto.java
+++ b/src/main/java/com/moddy/server/controller/user/dto/UserUpdateDto.java
@@ -1,0 +1,13 @@
+package com.moddy.server.controller.user.dto;
+
+import com.moddy.server.domain.user.Gender;
+import jakarta.validation.constraints.NotNull;
+
+@NotNull
+public record UserUpdateDto(
+        String name,
+        Gender gender,
+        String phoneNumber,
+        boolean isMarketingAgree
+) {
+}

--- a/src/main/java/com/moddy/server/domain/prefer_region/PreferRegion.java
+++ b/src/main/java/com/moddy/server/domain/prefer_region/PreferRegion.java
@@ -37,4 +37,8 @@ public class PreferRegion extends BaseTimeEntity {
     @NotNull
     private Region region;
 
+    public PreferRegion(Model model, Region region) {
+        this.model = model;
+        this.region = region;
+    }
 }

--- a/src/main/java/com/moddy/server/domain/prefer_region/PreferRegion.java
+++ b/src/main/java/com/moddy/server/domain/prefer_region/PreferRegion.java
@@ -21,7 +21,6 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@SuperBuilder
 public class PreferRegion extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moddy/server/service/model/ModelRegisterService.java
+++ b/src/main/java/com/moddy/server/service/model/ModelRegisterService.java
@@ -1,15 +1,64 @@
 package com.moddy.server.service.model;
 
+import com.moddy.server.common.exception.enums.ErrorCode;
+import com.moddy.server.common.exception.model.ConflictException;
+import com.moddy.server.common.exception.model.NotFoundException;
+import com.moddy.server.controller.designer.dto.response.UserCreateResponse;
+import com.moddy.server.controller.model.dto.request.ModelCreateRequest;
+import com.moddy.server.controller.user.dto.UserUpdateDto;
+import com.moddy.server.domain.model.Model;
 import com.moddy.server.domain.model.repository.ModelJpaRepository;
+import com.moddy.server.domain.prefer_region.PreferRegion;
 import com.moddy.server.domain.prefer_region.repository.PreferRegionJpaRepository;
+import com.moddy.server.domain.region.Region;
+import com.moddy.server.domain.region.repository.RegionJpaRepository;
+import com.moddy.server.domain.user.Role;
+import com.moddy.server.domain.user.User;
+import com.moddy.server.domain.user.repository.UserRepository;
+import com.moddy.server.external.s3.S3Service;
+import com.moddy.server.service.auth.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.moddy.server.common.exception.enums.ErrorCode.USER_NOT_FOUND_EXCEPTION;
 
 @Service
 @RequiredArgsConstructor
 public class ModelRegisterService {
     private final PreferRegionJpaRepository preferRegionJpaRepository;
     private final ModelJpaRepository modelJpaRepository;
+    private final RegionJpaRepository regionJpaRepository;
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+    private final AuthService authService;
+
+    @Transactional
+    public UserCreateResponse createModel(final Long userId, ModelCreateRequest request) {
+        if (modelJpaRepository.existsById(userId)) throw new ConflictException(ErrorCode.ALREADY_EXIST_MODEL_EXCEPTION);
+        updateUserInfos(userId, request.userInfoUpdate());
+        modelJpaRepository.modelRegister(userId, request.year());
+        createModelPreferRegions(userId, request.preferRegions());
+
+        return authService.createUserToken(userId.toString());
+    }
+
+    private void updateUserInfos(final Long userId, final UserUpdateDto userUpdateDto) {
+        final User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_EXCEPTION));
+        user.update(userUpdateDto.name(), userUpdateDto.gender(), userUpdateDto.phoneNumber(), userUpdateDto.isMarketingAgree(), s3Service.getDefaultProfileImageUrl(), Role.MODEL);
+    }
+
+    private void createModelPreferRegions(final Long modelId, final List<Long> preferRegions) {
+        Model model = modelJpaRepository.findById(modelId).orElseThrow(() -> new NotFoundException(ErrorCode.MODEL_NOT_FOUND_EXCEPTION));
+
+        preferRegions.forEach(preferRegionId -> {
+            Region region = regionJpaRepository.findById(preferRegionId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_REGION_EXCEPTION));
+            PreferRegion preferRegion = new PreferRegion(model, region);
+            preferRegionJpaRepository.save(preferRegion);
+        });
+    }
 
     public void deleteModelInfo(final Long modelId) {
         deleteModelPreferRegions(modelId);

--- a/src/main/java/com/moddy/server/service/model/ModelService.java
+++ b/src/main/java/com/moddy/server/service/model/ModelService.java
@@ -61,7 +61,6 @@ import java.util.stream.Collectors;
 public class ModelService {
 
     private final ModelJpaRepository modelJpaRepository;
-    private final UserRepository userRepository;
     private final DesignerJpaRepository designerJpaRepository;
     private final HairModelApplicationJpaRepository hairModelApplicationJpaRepository;
     private final HairServiceOfferJpaRepository hairServiceOfferJpaRepository;
@@ -69,9 +68,7 @@ public class ModelService {
     private final DayOffJpaRepository dayOffJpaRepository;
     private final PreferHairStyleJpaRepository preferHairStyleJpaRepository;
     private final PreferRegionJpaRepository preferRegionJpaRepository;
-    private final RegionJpaRepository regionJpaRepository;
     private final HairServiceRecordJpaRepository hairServiceRecordJpaRepository;
-    private final AuthService authService;
     private final S3Service s3Service;
 
 
@@ -102,27 +99,6 @@ public class ModelService {
         }).collect(Collectors.toList());
 
         return new ModelMainResponse(page, size, totalElements, modelApplyStatus, user.getName(), offerResponseList);
-    }
-
-    @Transactional
-    public UserCreateResponse createModel(long userId, ModelCreateRequest request) {
-
-        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
-
-        if (modelJpaRepository.existsById(userId)) throw new ConflictException(ErrorCode.ALREADY_EXIST_USER_EXCEPTION);
-
-        user.update(request.name(), request.gender(), request.phoneNumber(), request.isMarketingAgree(), s3Service.getDefaultProfileImageUrl(), Role.MODEL);
-
-        modelJpaRepository.modelRegister(userId, request.year());
-        Model model = modelJpaRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.MODEL_NOT_FOUND_EXCEPTION));
-
-        request.preferRegions().stream().forEach(preferRegionId -> {
-            Region region = regionJpaRepository.findById(preferRegionId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_REGION_EXCEPTION));
-            PreferRegion preferRegion = PreferRegion.builder().model(model).region(region).build();
-            preferRegionJpaRepository.save(preferRegion);
-        });
-
-        return authService.createUserToken(model.getId().toString());
     }
 
     @Transactional


### PR DESCRIPTION
## 관련 이슈번호
* Closes #198 

<br>
## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 2h / 3~4h

<br>

## 해결하려는 문제가 무엇인가요?
* 모델 회원가입 API가 AuthController에 있었는데, ModelController로 옮기고
* RegisterService로 모델 생성하는 부분 로직을 옮기는 작업을 하려고 했습니다!

<br>

## 고민이 되는 부분 
* ModelRegisterservice > createModel > `if (modelJpaRepository.existsById(userId)) throw new ConflictException(ErrorCode.ALREADY_EXIST_MODEL_EXCEPTION);` 해당 코드를 ModelRetrieveService로 처음에 옮겨서 isModelExist 라는 메소드를 만들었는데 분리하고자 했던 이유는 repository의존성 주입이 필요하지 않은 곳에서 모델이 존재하는지 확인하는 코드가 필요하지 않을까? 생각해서 분리하려고 하였으나 없는것 같아서  분리하지 않았음 
* Builder가 있었던 부분을 삭제하고 생성자를 만들었는데, 파트장님이 Builder 사용을 줄이면 좋다고 한 이유가 뭐였는지 기억이 안나서 왜 Builder 사용을 자제하라고 했지? 아티클을 찾아보면서 계속 생각을 해봤답니다..! 일단은 넘겨줄 값이 적어서 생성자 사용을 했습니다!  --------------> Dto를 사용해서 넘겨 주라고 했는데 ModelRegisterservice > createModelPreferRegions > `PreferRegion preferRegion = new PreferRegion(model, region);` 이부분의 파라미터 값을 Dto로 넘겨주라는것이 파트장님의 이야기 일까요..? 고민을 하다가 이미 Dto로 request값을 받아서  고민하다 사용하지 않았답니다..

<br>

## 트러블 슈팅
[순환참조 관련 문제 요약 & 느낀점 & 트러블 슈팅 기록](https://hellozo0.notion.site/Circular-Dependencies-5306126bc3b44fadb3643a7cb405b0d9?pvs=4)

<br>

## 어떻게 해결했나요?
모델 생성 제대로 작동하는지 확인~! 완료
<img width="1284" alt="스크린샷 2024-01-31 오전 1 01 02" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/720b648f-c0f8-4359-bf21-a372f8e28026">
<img width="308" alt="스크린샷 2024-01-31 오전 1 02 03" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/00911d41-7196-4ced-b92b-a24e1c913156">
<img width="1283" alt="스크린샷 2024-01-31 오전 1 02 20" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/e1d54744-f0bf-46aa-84e4-c986b2e44df5">
