### PR TITLE
#219 [Refactor] 모델 메인뷰 API Controller, Service 분리 

### DIFF
--- a/src/main/java/com/moddy/server/controller/model/ModelController.java
+++ b/src/main/java/com/moddy/server/controller/model/ModelController.java
@@ -11,7 +11,6 @@ import com.moddy.server.controller.model.dto.request.ModelApplicationRequest;
 import com.moddy.server.controller.model.dto.request.ModelCreateRequest;
 import com.moddy.server.controller.model.dto.response.ApplicationUserDetailResponse;
 import com.moddy.server.controller.model.dto.response.DetailOfferResponse;
-import com.moddy.server.controller.model.dto.response.ModelMainResponse;
 import com.moddy.server.controller.model.dto.response.OpenChatResponse;
 import com.moddy.server.service.model.ModelRegisterService;
 import com.moddy.server.service.model.ModelRetrieveService;
@@ -33,7 +32,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -74,22 +72,6 @@ public class ModelController {
             @Parameter(hidden = true) @UserId Long userId,
             @Valid @RequestBody ModelCreateRequest modelCreateRequest) {
         return SuccessResponse.success(SuccessCode.MODEL_CREATE_SUCCESS, modelRegisterService.createModel(userId, modelCreateRequest));
-    }
-
-    @Tag(name = "ModelController")
-    @Operation(summary = "[JWT] 모델 메인 뷰 조회", description = "모델 메인 뷰 조회 API입니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "모델 메인뷰 조회 성공", content = @Content(schema = @Schema(implementation = ModelMainResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-    })
-    @GetMapping("/model")
-    @SecurityRequirement(name = "JWT Auth")
-    public SuccessResponse<ModelMainResponse> getModelMainInfo(
-            @Parameter(hidden = true) @UserId Long userId,
-            @Parameter(name = "page", description = "페이지 ") @RequestParam(value = "page") int page,
-            @Parameter(name = "size", description = "페이지 ") @RequestParam(value = "size") int size) {
-        return SuccessResponse.success(SuccessCode.FIND_MODEL_MAIN_INFO_SUCCESS, modelService.getModelMainInfo(userId, page, size));
     }
 
     @Tag(name = "ModelController")

--- a/src/main/java/com/moddy/server/controller/offer/OfferController.java
+++ b/src/main/java/com/moddy/server/controller/offer/OfferController.java
@@ -1,0 +1,43 @@
+package com.moddy.server.controller.offer;
+
+import com.moddy.server.common.dto.ErrorResponse;
+import com.moddy.server.common.dto.SuccessResponse;
+import com.moddy.server.common.exception.enums.SuccessCode;
+import com.moddy.server.config.resolver.user.UserId;
+import com.moddy.server.controller.offer.dto.response.ModelMainOfferResponse;
+import com.moddy.server.service.offer.HairServiceOfferRetrieveService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OfferController {
+
+    private final HairServiceOfferRetrieveService hairServiceOfferRetrieveService;
+
+    @Tag(name = "ModelController")
+    @Operation(summary = "[JWT] 모델 메인 뷰 조회", description = "모델 메인 뷰 조회 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "모델 메인뷰 조회 성공", content = @Content(schema = @Schema(implementation = ModelMainOfferResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("/model")
+    @SecurityRequirement(name = "JWT Auth")
+    public SuccessResponse<ModelMainOfferResponse> getModelMainInfo(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Parameter(name = "page", description = "페이지 ") @RequestParam(value = "page") int page,
+            @Parameter(name = "size", description = "페이지 ") @RequestParam(value = "size") int size) {
+        return SuccessResponse.success(SuccessCode.FIND_MODEL_MAIN_INFO_SUCCESS, hairServiceOfferRetrieveService.getModelMainOfferInfo(userId, page, size));
+    }
+}

--- a/src/main/java/com/moddy/server/controller/offer/OfferController.java
+++ b/src/main/java/com/moddy/server/controller/offer/OfferController.java
@@ -35,9 +35,9 @@ public class OfferController {
     @GetMapping("/model")
     @SecurityRequirement(name = "JWT Auth")
     public SuccessResponse<ModelMainOfferResponse> getModelMainInfo(
-            @Parameter(hidden = true) @UserId Long userId,
+            @Parameter(hidden = true) @UserId Long modelId,
             @Parameter(name = "page", description = "페이지 ") @RequestParam(value = "page") int page,
             @Parameter(name = "size", description = "페이지 ") @RequestParam(value = "size") int size) {
-        return SuccessResponse.success(SuccessCode.FIND_MODEL_MAIN_INFO_SUCCESS, hairServiceOfferRetrieveService.getModelMainOfferInfo(userId, page, size));
+        return SuccessResponse.success(SuccessCode.FIND_MODEL_MAIN_INFO_SUCCESS, hairServiceOfferRetrieveService.getModelMainOfferInfo(modelId, page, size));
     }
 }

--- a/src/main/java/com/moddy/server/controller/offer/dto/response/ModelMainOfferResponse.java
+++ b/src/main/java/com/moddy/server/controller/offer/dto/response/ModelMainOfferResponse.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 @Schema(description = "모델 메인 뷰 제안서 Response DTO")
-public record ModelMainResponse(
+public record ModelMainOfferResponse(
         int page,
         int size,
         long total,

--- a/src/main/java/com/moddy/server/controller/offer/dto/response/ModelMainOfferResponse.java
+++ b/src/main/java/com/moddy/server/controller/offer/dto/response/ModelMainOfferResponse.java
@@ -1,11 +1,12 @@
-package com.moddy.server.controller.model.dto.response;
+package com.moddy.server.controller.offer.dto.response;
 
+import com.moddy.server.controller.model.dto.response.OfferResponse;
 import com.moddy.server.domain.model.ModelApplyStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(description = "모델 메인 뷰 Response DTO")
+@Schema(description = "모델 메인 뷰 제안서 Response DTO")
 public record ModelMainResponse(
         int page,
         int size,

--- a/src/main/java/com/moddy/server/service/application/HairModelApplicationRetrieveService.java
+++ b/src/main/java/com/moddy/server/service/application/HairModelApplicationRetrieveService.java
@@ -7,10 +7,12 @@ import com.moddy.server.controller.designer.dto.response.HairModelApplicationRes
 import com.moddy.server.controller.model.dto.ApplicationModelInfoDto;
 import com.moddy.server.domain.hair_model_application.HairModelApplication;
 import com.moddy.server.domain.hair_model_application.repository.HairModelApplicationJpaRepository;
+import com.moddy.server.domain.model.ModelApplyStatus;
 import com.moddy.server.domain.prefer_hair_style.PreferHairStyle;
 import com.moddy.server.domain.prefer_hair_style.repository.PreferHairStyleJpaRepository;
 import com.moddy.server.service.designer.DesignerRetrieveService;
 import com.moddy.server.service.model.ModelRetrieveService;
+import com.moddy.server.service.offer.HairServiceOfferRetrieveService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -51,6 +53,11 @@ public class HairModelApplicationRetrieveService {
                 applicationResponsesList
         );
     }
+
+    public boolean fetchModelApplyStatus(final Long modelId){
+        return hairModelApplicationJpaRepository.existsByModelId(modelId);
+    }
+
     private Page<HairModelApplication> findApplicationsByPaging(final int page, final int size) {
         PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
         Page<HairModelApplication> applicationPage = hairModelApplicationJpaRepository.findAll(pageRequest);

--- a/src/main/java/com/moddy/server/service/model/ModelRetrieveService.java
+++ b/src/main/java/com/moddy/server/service/model/ModelRetrieveService.java
@@ -5,8 +5,10 @@ import com.moddy.server.common.exception.model.NotFoundException;
 import com.moddy.server.controller.auth.dto.response.RegionResponse;
 import com.moddy.server.controller.model.dto.ApplicationModelInfoDto;
 import com.moddy.server.domain.model.Model;
+import com.moddy.server.domain.model.ModelApplyStatus;
 import com.moddy.server.domain.model.repository.ModelJpaRepository;
 import com.moddy.server.domain.region.repository.RegionJpaRepository;
+import com.moddy.server.service.offer.HairServiceOfferRetrieveService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,5 +35,10 @@ public class ModelRetrieveService {
         }).collect(Collectors.toList());
 
         return regionResponseList;
+    }
+
+    public String getModelName(final Long modelId) {
+        Model model = modelJpaRepository.findById(modelId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MODEL_INFO));
+        return model.getName();
     }
 }

--- a/src/main/java/com/moddy/server/service/model/ModelService.java
+++ b/src/main/java/com/moddy/server/service/model/ModelService.java
@@ -2,18 +2,11 @@ package com.moddy.server.service.model;
 
 
 import com.moddy.server.common.exception.enums.ErrorCode;
-import com.moddy.server.common.exception.model.ConflictException;
 import com.moddy.server.common.exception.model.NotFoundException;
-import com.moddy.server.controller.designer.dto.response.UserCreateResponse;
 import com.moddy.server.controller.model.dto.request.ModelApplicationRequest;
-import com.moddy.server.controller.model.dto.request.ModelCreateRequest;
 import com.moddy.server.controller.model.dto.response.ApplicationUserDetailResponse;
-import com.moddy.server.controller.model.dto.response.DesignerInfoOpenChatResponse;
 import com.moddy.server.controller.model.dto.response.DesignerInfoResponse;
 import com.moddy.server.controller.model.dto.response.DetailOfferResponse;
-import com.moddy.server.controller.model.dto.response.ModelMainResponse;
-import com.moddy.server.controller.model.dto.response.OfferResponse;
-import com.moddy.server.controller.model.dto.response.OpenChatResponse;
 import com.moddy.server.controller.model.dto.response.StyleDetailResponse;
 import com.moddy.server.domain.day_off.DayOff;
 import com.moddy.server.domain.day_off.repository.DayOffJpaRepository;
@@ -26,32 +19,19 @@ import com.moddy.server.domain.hair_service_offer.repository.HairServiceOfferJpa
 import com.moddy.server.domain.hair_service_record.HairServiceRecord;
 import com.moddy.server.domain.hair_service_record.repository.HairServiceRecordJpaRepository;
 import com.moddy.server.domain.model.Model;
-import com.moddy.server.domain.model.ModelApplyStatus;
 import com.moddy.server.domain.model.repository.ModelJpaRepository;
 import com.moddy.server.domain.prefer_hair_style.PreferHairStyle;
 import com.moddy.server.domain.prefer_hair_style.repository.PreferHairStyleJpaRepository;
 import com.moddy.server.domain.prefer_offer_condition.OfferCondition;
 import com.moddy.server.domain.prefer_offer_condition.PreferOfferCondition;
 import com.moddy.server.domain.prefer_offer_condition.repository.PreferOfferConditionJpaRepository;
-import com.moddy.server.domain.prefer_region.PreferRegion;
 import com.moddy.server.domain.prefer_region.repository.PreferRegionJpaRepository;
-import com.moddy.server.domain.region.Region;
-import com.moddy.server.domain.region.repository.RegionJpaRepository;
-import com.moddy.server.domain.user.Role;
-import com.moddy.server.domain.user.User;
-import com.moddy.server.domain.user.repository.UserRepository;
 import com.moddy.server.external.s3.S3Service;
-import com.moddy.server.service.auth.AuthService;
-import com.moddy.server.service.designer.DesignerRetrieveService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -71,37 +51,7 @@ public class ModelService {
     private final PreferRegionJpaRepository preferRegionJpaRepository;
     private final HairServiceRecordJpaRepository hairServiceRecordJpaRepository;
     private final S3Service s3Service;
-    private final DesignerRetrieveService designerRetrieveService;
 
-
-    public ModelMainResponse getModelMainInfo(Long userId, int page, int size) {
-
-        User user = modelJpaRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MODEL_INFO));
-
-        Page<HairServiceOffer> offerPage = findOffersByPaging(userId, page, size);
-        long totalElements = offerPage.getTotalElements();
-
-        boolean applyStatus = hairModelApplicationJpaRepository.existsByModelId(userId);
-        boolean offerStatus = hairServiceOfferJpaRepository.existsByModelId(userId);
-        ModelApplyStatus modelApplyStatus = calModelStatus(applyStatus, offerStatus);
-
-        if (modelApplyStatus != ModelApplyStatus.APPLY_AND_OFFER) {
-            return new ModelMainResponse(page, size, totalElements, modelApplyStatus, user.getName(), new ArrayList<>());
-        }
-
-        List<OfferResponse> offerResponseList = offerPage.stream().map(offer -> {
-            Designer designer = offer.getDesigner();
-            List<PreferOfferCondition> preferOfferCondition = preferOfferConditionJpaRepository.findTop2ByHairServiceOfferId(offer.getId());
-            List<String> offerConditionTop2List = preferOfferCondition.stream().map(offerCondition -> {
-                return offerCondition.getOfferCondition().getValue();
-            }).collect(Collectors.toList());
-
-            OfferResponse offerResponse = new OfferResponse(offer.getId(), designer.getProfileImgUrl(), designer.getName(), designer.getHairShop().getName(), offerConditionTop2List, offer.getIsClicked());
-            return offerResponse;
-        }).collect(Collectors.toList());
-
-        return new ModelMainResponse(page, size, totalElements, modelApplyStatus, user.getName(), offerResponseList);
-    }
 
     @Transactional
     public void postApplication(Long userId, MultipartFile modelImgUrl, MultipartFile applicationCaptureImgUrl, ModelApplicationRequest applicationInfo) {
@@ -198,20 +148,6 @@ public class ModelService {
         }
     }
 
-    private Page<HairServiceOffer> findOffersByPaging(Long userId, int page, int size) {
-        PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
-        Page<HairServiceOffer> offerPage = hairServiceOfferJpaRepository.findByModelId(userId, pageRequest);
 
-        return offerPage;
-    }
-
-    private ModelApplyStatus calModelStatus(boolean apply, boolean offer) {
-
-        if (!apply && !offer) return ModelApplyStatus.NOTHING;
-        else if (apply && !offer) return ModelApplyStatus.APPLY;
-        else if (apply && offer) return ModelApplyStatus.APPLY_AND_OFFER;
-        else throw new NotFoundException(ErrorCode.NOT_FOUND_MODEL_STATUS);
-
-    }
 
 }

--- a/src/main/java/com/moddy/server/service/offer/HairServiceOfferRetrieveService.java
+++ b/src/main/java/com/moddy/server/service/offer/HairServiceOfferRetrieveService.java
@@ -4,14 +4,28 @@ import com.moddy.server.common.exception.enums.ErrorCode;
 import com.moddy.server.common.exception.model.NotFoundException;
 import com.moddy.server.controller.model.dto.DesignerInfoOpenChatDto;
 import com.moddy.server.controller.model.dto.response.DesignerInfoOpenChatResponse;
+import com.moddy.server.controller.model.dto.response.OfferResponse;
 import com.moddy.server.controller.model.dto.response.OpenChatResponse;
+import com.moddy.server.controller.offer.dto.response.ModelMainOfferResponse;
+import com.moddy.server.domain.designer.Designer;
 import com.moddy.server.domain.hair_service_offer.HairServiceOffer;
 import com.moddy.server.domain.hair_service_offer.repository.HairServiceOfferJpaRepository;
+import com.moddy.server.domain.model.ModelApplyStatus;
+import com.moddy.server.domain.prefer_offer_condition.PreferOfferCondition;
+import com.moddy.server.domain.prefer_offer_condition.repository.PreferOfferConditionJpaRepository;
 import com.moddy.server.service.application.HairModelApplicationRetrieveService;
 import com.moddy.server.service.designer.DesignerRetrieveService;
+import com.moddy.server.service.model.ModelRetrieveService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,8 +33,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class HairServiceOfferRetrieveService {
 
     private final HairServiceOfferJpaRepository hairServiceOfferJpaRepository;
+    private final PreferOfferConditionJpaRepository preferOfferConditionJpaRepository;
     private final DesignerRetrieveService designerRetrieveService;
     private final HairModelApplicationRetrieveService hairModelApplicationRetrieveService;
+    private final ModelRetrieveService modelRetrieveService;
 
     public OpenChatResponse getOpenChatInfo(final Long userId, final Long offerId) {
         HairServiceOffer hairServiceOffer = hairServiceOfferJpaRepository.findById(offerId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUNT_OFFER_EXCEPTION));
@@ -35,5 +51,50 @@ public class HairServiceOfferRetrieveService {
         OpenChatResponse openChatResponse = new OpenChatResponse(hairModelApplicationRetrieveService.getApplicationCaptureUrl(applicationId), openChatDto.kakaoUrl(), response);
 
         return openChatResponse;
+    }
+
+    public ModelMainOfferResponse getModelMainOfferInfo(final Long modelId, final int page, final int size) {
+        String modelName = modelRetrieveService.getModelName(modelId);
+
+        Page<HairServiceOffer> offerPage = findOffersByPaging(modelId, page, size);
+        long totalElements = offerPage.getTotalElements();
+
+        ModelApplyStatus modelApplyStatus = calModelApplyAndOfferStatus(modelId);
+        if (modelApplyStatus != ModelApplyStatus.APPLY_AND_OFFER) {
+            return new ModelMainOfferResponse(page, size, totalElements, modelApplyStatus, modelName, new ArrayList<>());
+        }
+        return new ModelMainOfferResponse(page, size, totalElements, modelApplyStatus, modelName, getModelMainOfferList(offerPage));
+    }
+
+    private ModelApplyStatus calModelApplyAndOfferStatus(final Long modelId) {
+        boolean applyStatus = hairModelApplicationRetrieveService.fetchModelApplyStatus(modelId);
+        boolean offerStatus = hairServiceOfferJpaRepository.existsByModelId(modelId);
+
+        if (!applyStatus && !offerStatus) return ModelApplyStatus.NOTHING;
+        else if (applyStatus && !offerStatus) return ModelApplyStatus.APPLY;
+        else if (applyStatus && offerStatus) return ModelApplyStatus.APPLY_AND_OFFER;
+        else throw new NotFoundException(ErrorCode.NOT_FOUND_MODEL_STATUS);
+    }
+
+    private List<OfferResponse> getModelMainOfferList(final Page<HairServiceOffer> offerPage) {
+        List<OfferResponse> offerResponseList = offerPage.stream().map(offer -> {
+            Designer designer = offer.getDesigner();
+            List<PreferOfferCondition> preferOfferCondition = preferOfferConditionJpaRepository.findTop2ByHairServiceOfferId(offer.getId());
+            List<String> offerConditionTop2List = preferOfferCondition.stream().map(offerCondition -> {
+                return offerCondition.getOfferCondition().getValue();
+            }).collect(Collectors.toList());
+
+            OfferResponse offerResponse = new OfferResponse(offer.getId(), designer.getProfileImgUrl(), designer.getName(), designer.getHairShop().getName(), offerConditionTop2List, offer.getIsClicked());
+            return offerResponse;
+        }).collect(Collectors.toList());
+
+        return offerResponseList;
+    }
+
+    private Page<HairServiceOffer> findOffersByPaging(final Long modelId, final int page, final int size) {
+        PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<HairServiceOffer> offerPage = hairServiceOfferJpaRepository.findByModelId(modelId, pageRequest);
+
+        return offerPage;
     }
 }


### PR DESCRIPTION
## 관련 이슈번호
* Closes #219 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 1h / 1h 40m

## 해결하려는 문제가 무엇인가요?
* 모델 메인뷰 API Controller, Service 분리 

## 어떻게 해결했나요?
* 함수 내에서도 분리할 수 있는 기능들은 최대한 묶어서 분리했습니다!
* 그리고 메인 뷰의 정렬 기준이 id 였는데 명확한 의미 구분을 위해서 createdAt 기분으로 바꿨습니다! -> DB에서 조작해서 정렬값 바뀌는지 확인 완료
* 추가로 public으로 다른 Service에서  정보 가져오는 경우에는 '메소드명에 get이 아닌 가져와진다는 의미의 fetch를 사용해 구분'을 했습니다! 

<img width="341" alt="스크린샷 2024-01-31 오후 5 39 42" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/ed46990a-cdab-4eeb-b371-37382eb5c3ab">

<img width="953" alt="스크린샷 2024-01-31 오후 5 37 11" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/b10be8f8-6595-4701-b47d-dcb1195a0726">

<img width="352" alt="스크린샷 2024-01-31 오후 5 39 07" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/172cc936-58da-439b-b165-f885ebb62927">
