### PR TITLE
#230 [Refactor] 지원서 작성 API Controller, Service 분리

### DIFF
--- a/src/main/java/com/moddy/server/controller/application/ApplicationController.java
+++ b/src/main/java/com/moddy/server/controller/application/ApplicationController.java
@@ -1,0 +1,49 @@
+package com.moddy.server.controller.application;
+
+import com.moddy.server.common.dto.ErrorResponse;
+import com.moddy.server.common.dto.SuccessNonDataResponse;
+import com.moddy.server.common.exception.enums.SuccessCode;
+import com.moddy.server.config.resolver.user.UserId;
+import com.moddy.server.controller.model.dto.request.ModelApplicationRequest;
+import com.moddy.server.service.application.HairModelApplicationRegisterService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class ApplicationController {
+
+    private final HairModelApplicationRegisterService hairModelApplicationRegisterService;
+
+    @Tag(name = "ModelController")
+    @Operation(summary = "[JWT] 모델 지원서 작성", description = "모델 지원서 작성 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "모델 지원서 작성 성공"),
+            @ApiResponse(responseCode = "400", description = "인증 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @SecurityRequirement(name = "JWT Auth")
+    @PostMapping(value = "/model/application", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public SuccessNonDataResponse submitModelApplication(
+            @Parameter(hidden = true) @UserId Long userId,
+            @RequestPart(value = "modelImgUrl", required = false) MultipartFile modelImgUrl,
+            @RequestPart(value = "applicationCaptureImgUrl", required = false) MultipartFile applicationCaptureImgUrl,
+            @RequestPart(value = "applicationInfo") @Valid ModelApplicationRequest applicationInfo) {
+        hairModelApplicationRegisterService.postApplication(userId, modelImgUrl, applicationCaptureImgUrl, applicationInfo);
+        return SuccessNonDataResponse.success(SuccessCode.CREATE_MODEL_APPLICATION_SUCCESS);
+    }
+}
+

--- a/src/main/java/com/moddy/server/controller/application/ApplicationController.java
+++ b/src/main/java/com/moddy/server/controller/application/ApplicationController.java
@@ -38,11 +38,11 @@ public class ApplicationController {
     @SecurityRequirement(name = "JWT Auth")
     @PostMapping(value = "/model/application", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public SuccessNonDataResponse submitModelApplication(
-            @Parameter(hidden = true) @UserId Long userId,
+            @Parameter(hidden = true) @UserId Long modelId,
             @RequestPart(value = "modelImgUrl", required = false) MultipartFile modelImgUrl,
             @RequestPart(value = "applicationCaptureImgUrl", required = false) MultipartFile applicationCaptureImgUrl,
             @RequestPart(value = "applicationInfo") @Valid ModelApplicationRequest applicationInfo) {
-        hairModelApplicationRegisterService.postApplication(userId, modelImgUrl, applicationCaptureImgUrl, applicationInfo);
+        hairModelApplicationRegisterService.postApplication(modelId, modelImgUrl, applicationCaptureImgUrl, applicationInfo);
         return SuccessNonDataResponse.success(SuccessCode.CREATE_MODEL_APPLICATION_SUCCESS);
     }
 }

--- a/src/main/java/com/moddy/server/controller/model/ModelController.java
+++ b/src/main/java/com/moddy/server/controller/model/ModelController.java
@@ -7,7 +7,6 @@ import com.moddy.server.common.exception.enums.SuccessCode;
 import com.moddy.server.config.resolver.user.UserId;
 import com.moddy.server.controller.auth.dto.response.RegionResponse;
 import com.moddy.server.controller.designer.dto.response.UserCreateResponse;
-import com.moddy.server.controller.model.dto.request.ModelApplicationRequest;
 import com.moddy.server.controller.model.dto.request.ModelCreateRequest;
 import com.moddy.server.controller.model.dto.response.ApplicationUserDetailResponse;
 import com.moddy.server.controller.model.dto.response.DetailOfferResponse;
@@ -27,17 +26,13 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
 
 @RestController
@@ -138,24 +133,6 @@ public class ModelController {
             @Parameter(name = "offerId", description = "제안서아이디") @PathVariable(value = "offerId") Long offerId) {
         modelService.updateOfferAgreeStatus(offerId);
         return SuccessNonDataResponse.success(SuccessCode.OFFER_ACCEPT_SUCCESS);
-    }
-
-    @Tag(name = "ModelController")
-    @Operation(summary = "[JWT] 모델 지원서 작성", description = "모델 지원서 작성 API입니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "모델 지원서 작성 성공"),
-            @ApiResponse(responseCode = "400", description = "인증 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-    })
-    @SecurityRequirement(name = "JWT Auth")
-    @PostMapping(value = "/model/application", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-    public SuccessNonDataResponse submitModelApplication(
-            @Parameter(hidden = true) @UserId Long userId,
-            @RequestPart(value = "modelImgUrl", required = false) MultipartFile modelImgUrl,
-            @RequestPart(value = "applicationCaptureImgUrl", required = false) MultipartFile applicationCaptureImgUrl,
-            @RequestPart(value = "applicationInfo") @Valid ModelApplicationRequest applicationInfo) {
-        modelService.postApplication(userId, modelImgUrl, applicationCaptureImgUrl, applicationInfo);
-        return SuccessNonDataResponse.success(SuccessCode.CREATE_MODEL_APPLICATION_SUCCESS);
     }
 
     @Tag(name = "ModelController")

--- a/src/main/java/com/moddy/server/domain/hair_model_application/HairModelApplication.java
+++ b/src/main/java/com/moddy/server/domain/hair_model_application/HairModelApplication.java
@@ -14,7 +14,6 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@SuperBuilder
 public class HairModelApplication extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,4 +40,12 @@ public class HairModelApplication extends BaseTimeEntity {
     @NotNull
     private String applicationCaptureUrl;
 
+    public HairModelApplication(Model model, HairLength hairLength, String hairDetail, String modelImgUrl, String instagramId, String applicationCaptureUrl) {
+        this.model = model;
+        this.hairLength = hairLength;
+        this.hairDetail = hairDetail;
+        this.modelImgUrl = modelImgUrl;
+        this.instagramId = instagramId;
+        this.applicationCaptureUrl = applicationCaptureUrl;
+    }
 }

--- a/src/main/java/com/moddy/server/domain/hair_service_record/HairServiceRecord.java
+++ b/src/main/java/com/moddy/server/domain/hair_service_record/HairServiceRecord.java
@@ -13,7 +13,6 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@SuperBuilder
 public class HairServiceRecord extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,5 +30,9 @@ public class HairServiceRecord extends BaseTimeEntity {
     @NotNull
     private ServiceRecordTerm serviceRecordTerm;
 
-
+    public HairServiceRecord(HairModelApplication hairModelApplication, ServiceRecord serviceRecord, ServiceRecordTerm serviceRecordTerm) {
+        this.hairModelApplication = hairModelApplication;
+        this.serviceRecord = serviceRecord;
+        this.serviceRecordTerm = serviceRecordTerm;
+    }
 }

--- a/src/main/java/com/moddy/server/domain/prefer_hair_style/PreferHairStyle.java
+++ b/src/main/java/com/moddy/server/domain/prefer_hair_style/PreferHairStyle.java
@@ -11,7 +11,6 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@SuperBuilder
 public class PreferHairStyle extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,4 +24,8 @@ public class PreferHairStyle extends BaseTimeEntity {
     @NotNull
     private HairStyle hairStyle;
 
+    public PreferHairStyle(HairModelApplication hairModelApplication, HairStyle hairStyle) {
+        this.hairModelApplication = hairModelApplication;
+        this.hairStyle = hairStyle;
+    }
 }

--- a/src/main/java/com/moddy/server/service/application/HairModelApplicationRegisterService.java
+++ b/src/main/java/com/moddy/server/service/application/HairModelApplicationRegisterService.java
@@ -1,12 +1,21 @@
 package com.moddy.server.service.application;
 
+import com.moddy.server.common.exception.enums.ErrorCode;
+import com.moddy.server.common.exception.model.NotFoundException;
+import com.moddy.server.controller.model.dto.request.ModelApplicationRequest;
 import com.moddy.server.domain.hair_model_application.HairModelApplication;
 import com.moddy.server.domain.hair_model_application.repository.HairModelApplicationJpaRepository;
+import com.moddy.server.domain.hair_service_record.HairServiceRecord;
 import com.moddy.server.domain.hair_service_record.repository.HairServiceRecordJpaRepository;
+import com.moddy.server.domain.model.Model;
+import com.moddy.server.domain.model.repository.ModelJpaRepository;
+import com.moddy.server.domain.prefer_hair_style.PreferHairStyle;
 import com.moddy.server.domain.prefer_hair_style.repository.PreferHairStyleJpaRepository;
 import com.moddy.server.external.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -17,6 +26,20 @@ public class HairModelApplicationRegisterService {
     private final HairModelApplicationJpaRepository hairModelApplicationJpaRepository;
     private final PreferHairStyleJpaRepository preferHairStyleJpaRepository;
     private final HairServiceRecordJpaRepository hairServiceRecordJpaRepository;
+    private final ModelJpaRepository modelJpaRepository;
+
+    @Transactional
+    public void postApplication(final Long modelId, final MultipartFile modelImgUrl, final MultipartFile applicationCaptureImgUrl, final ModelApplicationRequest applicationInfo) {
+        Model model = modelJpaRepository.findById(modelId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MODEL_INFO));
+        String s3ModelImgUrl = s3Service.uploadProfileImage(modelImgUrl, model.getRole());
+        String s3applicationCaptureImgUrl = s3Service.uploadApplicationImage(applicationCaptureImgUrl);
+
+        HairModelApplication hairModelApplication = new HairModelApplication(model,applicationInfo.hairLength(),applicationInfo.hairDetail(),s3ModelImgUrl,applicationInfo.instagramId(),s3applicationCaptureImgUrl);
+        hairModelApplicationJpaRepository.save(hairModelApplication);
+
+        savePreferHairStyles(applicationInfo, hairModelApplication);
+        saveHairServiceRecords(applicationInfo, hairModelApplication);
+    }
 
     public void deleteModelApplications(final Long modelId) {
         List<HairModelApplication> hairModelApplications = hairModelApplicationJpaRepository.findAllByModelId(modelId);
@@ -31,5 +54,19 @@ public class HairModelApplicationRegisterService {
     private void deleteApplicationImage(final HairModelApplication hairModelApplication) {
         s3Service.deleteS3Image(hairModelApplication.getApplicationCaptureUrl());
         s3Service.deleteS3Image(hairModelApplication.getModelImgUrl());
+    }
+
+    private void savePreferHairStyles(final ModelApplicationRequest applicationInfo, final HairModelApplication hairModelApplication){
+        applicationInfo.preferHairStyles().stream().forEach(hairStyle -> {
+            PreferHairStyle preferHairStyle = new PreferHairStyle(hairModelApplication, hairStyle);
+            preferHairStyleJpaRepository.save(preferHairStyle);
+        });
+    }
+
+    private void saveHairServiceRecords(final ModelApplicationRequest applicationInfo, final HairModelApplication hairModelApplication){
+        applicationInfo.getHairServiceRecords().stream().forEach(modelHairServiceRecord -> {
+            HairServiceRecord hairServiceRecord = new HairServiceRecord(hairModelApplication,modelHairServiceRecord.hairService(), modelHairServiceRecord.hairServiceTerm());
+            hairServiceRecordJpaRepository.save(hairServiceRecord);
+        });
     }
 }

--- a/src/main/java/com/moddy/server/service/model/ModelService.java
+++ b/src/main/java/com/moddy/server/service/model/ModelService.java
@@ -2,18 +2,12 @@ package com.moddy.server.service.model;
 
 
 import com.moddy.server.common.exception.enums.ErrorCode;
-import com.moddy.server.common.exception.model.ConflictException;
 import com.moddy.server.common.exception.model.NotFoundException;
-import com.moddy.server.controller.designer.dto.response.UserCreateResponse;
-import com.moddy.server.controller.model.dto.request.ModelApplicationRequest;
-import com.moddy.server.controller.model.dto.request.ModelCreateRequest;
 import com.moddy.server.controller.model.dto.response.ApplicationUserDetailResponse;
-import com.moddy.server.controller.model.dto.response.DesignerInfoOpenChatResponse;
 import com.moddy.server.controller.model.dto.response.DesignerInfoResponse;
 import com.moddy.server.controller.model.dto.response.DetailOfferResponse;
 import com.moddy.server.controller.model.dto.response.ModelMainResponse;
 import com.moddy.server.controller.model.dto.response.OfferResponse;
-import com.moddy.server.controller.model.dto.response.OpenChatResponse;
 import com.moddy.server.controller.model.dto.response.StyleDetailResponse;
 import com.moddy.server.domain.day_off.DayOff;
 import com.moddy.server.domain.day_off.repository.DayOffJpaRepository;
@@ -23,8 +17,6 @@ import com.moddy.server.domain.hair_model_application.HairModelApplication;
 import com.moddy.server.domain.hair_model_application.repository.HairModelApplicationJpaRepository;
 import com.moddy.server.domain.hair_service_offer.HairServiceOffer;
 import com.moddy.server.domain.hair_service_offer.repository.HairServiceOfferJpaRepository;
-import com.moddy.server.domain.hair_service_record.HairServiceRecord;
-import com.moddy.server.domain.hair_service_record.repository.HairServiceRecordJpaRepository;
 import com.moddy.server.domain.model.Model;
 import com.moddy.server.domain.model.ModelApplyStatus;
 import com.moddy.server.domain.model.repository.ModelJpaRepository;
@@ -33,23 +25,14 @@ import com.moddy.server.domain.prefer_hair_style.repository.PreferHairStyleJpaRe
 import com.moddy.server.domain.prefer_offer_condition.OfferCondition;
 import com.moddy.server.domain.prefer_offer_condition.PreferOfferCondition;
 import com.moddy.server.domain.prefer_offer_condition.repository.PreferOfferConditionJpaRepository;
-import com.moddy.server.domain.prefer_region.PreferRegion;
 import com.moddy.server.domain.prefer_region.repository.PreferRegionJpaRepository;
-import com.moddy.server.domain.region.Region;
-import com.moddy.server.domain.region.repository.RegionJpaRepository;
-import com.moddy.server.domain.user.Role;
 import com.moddy.server.domain.user.User;
-import com.moddy.server.domain.user.repository.UserRepository;
-import com.moddy.server.external.s3.S3Service;
-import com.moddy.server.service.auth.AuthService;
-import com.moddy.server.service.designer.DesignerRetrieveService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,10 +52,6 @@ public class ModelService {
     private final DayOffJpaRepository dayOffJpaRepository;
     private final PreferHairStyleJpaRepository preferHairStyleJpaRepository;
     private final PreferRegionJpaRepository preferRegionJpaRepository;
-    private final HairServiceRecordJpaRepository hairServiceRecordJpaRepository;
-    private final S3Service s3Service;
-    private final DesignerRetrieveService designerRetrieveService;
-
 
     public ModelMainResponse getModelMainInfo(Long userId, int page, int size) {
 
@@ -101,29 +80,6 @@ public class ModelService {
         }).collect(Collectors.toList());
 
         return new ModelMainResponse(page, size, totalElements, modelApplyStatus, user.getName(), offerResponseList);
-    }
-
-    @Transactional
-    public void postApplication(Long userId, MultipartFile modelImgUrl, MultipartFile applicationCaptureImgUrl, ModelApplicationRequest applicationInfo) {
-
-        Model model = modelJpaRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MODEL_INFO));
-        String s3ModelImgUrl = s3Service.uploadProfileImage(modelImgUrl, model.getRole());
-        String s3applicationCaptureImgUrl = s3Service.uploadApplicationImage(applicationCaptureImgUrl);
-
-        HairModelApplication hairModelApplication = HairModelApplication.builder().model(model).hairLength(applicationInfo.hairLength()).hairDetail(applicationInfo.hairDetail()).modelImgUrl(s3ModelImgUrl).instagramId(applicationInfo.instagramId()).applicationCaptureUrl(s3applicationCaptureImgUrl).build();
-
-        hairModelApplicationJpaRepository.save(hairModelApplication);
-
-        applicationInfo.preferHairStyles().stream().forEach(hairStyle -> {
-            PreferHairStyle preferHairStyle = PreferHairStyle.builder().hairModelApplication(hairModelApplication).hairStyle(hairStyle).build();
-            preferHairStyleJpaRepository.save(preferHairStyle);
-        });
-
-        applicationInfo.getHairServiceRecords().stream().forEach(modelHairServiceRecord -> {
-            HairServiceRecord hairServiceRecord = HairServiceRecord.builder().hairModelApplication(hairModelApplication).serviceRecord(modelHairServiceRecord.hairService()).serviceRecordTerm(modelHairServiceRecord.hairServiceTerm()).build();
-            hairServiceRecordJpaRepository.save(hairServiceRecord);
-        });
-
     }
 
     @Transactional


### PR DESCRIPTION
## 관련 이슈번호
* Closes #230

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 2h/1h

## 해결하려는 문제가 무엇인가요?
* 지원서 작성 API Controller, Service 분리

## 어떻게 해결했나요?
* ApplicationRegisterService >  postApplication >`Model model = modelJpaRepository.findById(modelId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MODEL_INFO));`에서 ModelJpaRepository를 사용해서 의존성을 추가했는데요..........., 이부분을 ModelRetrieveService로 빼서 Model 객체를 return하는 로직을 추가할까 하려다가... 말았는데 빼는게 정답이였을까요... 뭐가 나을지 모르겠네요..!
<img width="614" alt="스크린샷 2024-02-01 오전 1 00 10" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/2d9919e3-3080-4dfa-82a1-b4576faff3d0">


* DB에 저장 확인~
<img width="796" alt="스크린샷 2024-02-01 오전 12 52 22" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/cf770d79-0c98-4ab0-82de-bf3cb1d9b796">
<img width="382" alt="스크린샷 2024-02-01 오전 12 51 59" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/29235a88-ea3e-4a50-b25d-cc95de95d28d">
