### PR TITLE
#268 [feat] 지원서 유무 확인 API에 ApplicationId 추가

### DIFF
--- a/src/main/java/com/moddy/server/common/dto/TokenPair.java
+++ b/src/main/java/com/moddy/server/common/dto/TokenPair.java
@@ -1,9 +1,5 @@
 package com.moddy.server.common.dto;
 
-
-import lombok.Getter;
-import lombok.ToString;
-
 public record TokenPair(
         String accessToken, String refreshToken
 ) {

--- a/src/main/java/com/moddy/server/controller/application/ApplicationRetrieveController.java
+++ b/src/main/java/com/moddy/server/controller/application/ApplicationRetrieveController.java
@@ -1,10 +1,10 @@
 package com.moddy.server.controller.application;
 
 import com.moddy.server.common.dto.ErrorResponse;
-import com.moddy.server.common.dto.SuccessNonDataResponse;
 import com.moddy.server.common.dto.SuccessResponse;
 import com.moddy.server.common.exception.enums.SuccessCode;
 import com.moddy.server.config.resolver.user.UserId;
+import com.moddy.server.controller.application.dto.response.ApplicationIdResponse;
 import com.moddy.server.controller.designer.dto.response.ApplicationDetailInfoResponse;
 import com.moddy.server.controller.designer.dto.response.ApplicationInfoResponse;
 import com.moddy.server.controller.designer.dto.response.DesignerMainResponse;
@@ -130,17 +130,16 @@ public class ApplicationRetrieveController {
 
     @Operation(summary = "[JWT] 나의 지원서 유무 확인하기", description = "마이페이지에서 유효한 지원서 유무를 확인하는 API입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "유효한 지원서 존재여부 조회 성공", content = @Content(schema = @Schema(implementation = ApplicationDetailInfoResponse.class))),
+            @ApiResponse(responseCode = "200", description = "유효한 지원서 존재여부 조회 성공", content = @Content(schema = @Schema(implementation = ApplicationIdResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "해당 지원서를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @GetMapping("/check")
     @SecurityRequirement(name = "JWT Auth")
-    public SuccessNonDataResponse getValidApplicationStatus(
+    public SuccessResponse<ApplicationIdResponse> getValidApplicationStatus(
             @Parameter(hidden = true) @UserId Long modelId) {
-        hairModelApplicationRetrieveService.checkValidApplicationStatus(modelId);
-        return SuccessNonDataResponse.success(SuccessCode.CHECK_VALID_APPLICATION_SUCCESS);
+        return SuccessResponse.success(SuccessCode.CHECK_VALID_APPLICATION_SUCCESS, hairModelApplicationRetrieveService.checkValidApplicationStatus(modelId));
     }
 
 }

--- a/src/main/java/com/moddy/server/controller/application/dto/response/ApplicationIdResponse.java
+++ b/src/main/java/com/moddy/server/controller/application/dto/response/ApplicationIdResponse.java
@@ -1,0 +1,6 @@
+package com.moddy.server.controller.application.dto.response;
+
+public record ApplicationIdResponse(
+        Long applicationId
+) {
+}

--- a/src/main/java/com/moddy/server/service/application/HairModelApplicationRetrieveService.java
+++ b/src/main/java/com/moddy/server/service/application/HairModelApplicationRetrieveService.java
@@ -2,6 +2,7 @@ package com.moddy.server.service.application;
 
 import com.moddy.server.common.exception.enums.ErrorCode;
 import com.moddy.server.common.exception.model.NotFoundException;
+import com.moddy.server.controller.application.dto.response.ApplicationIdResponse;
 import com.moddy.server.controller.application.dto.response.ApplicationInfoDetailResponse;
 import com.moddy.server.controller.designer.dto.response.DesignerMainResponse;
 import com.moddy.server.controller.designer.dto.response.DownloadUrlResponseDto;
@@ -103,10 +104,12 @@ public class HairModelApplicationRetrieveService {
                 hairModelApplication.getExpiredDate().format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
     }
 
-    public void checkValidApplicationStatus(final Long modelId){
+    public ApplicationIdResponse checkValidApplicationStatus(final Long modelId){
         HairModelApplication hairModelApplication = hairModelApplicationJpaRepository.findFirstByModelIdOrderByCreatedAtDesc(modelId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_APPLICATION_EXCEPTION));
 
         if(hairModelApplication.isExpired()) throw new NotFoundException(ErrorCode.NOT_FOUND_VALID_APPLICATION_EXCEPTION);
+
+        return new ApplicationIdResponse(hairModelApplication.getId());
     }
 
     public boolean fetchModelApplyStatus(final Long modelId) {


### PR DESCRIPTION
## 관련 이슈번호
* Closes #268 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 10m / 10m

## 해결하려는 문제가 무엇인가요?
*  지원서 유무 확인 API에 ApplicationId 추가해줘야지 지원서 상세보기 API 재사용이 가능해진다..! 떼쿵 

## 어떻게 해결했나요?
* response 로 성공하는 경우 ApplicationId를 리턴해준다.
<img width="388" alt="스크린샷 2024-03-05 오전 6 49 07" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/76c11f82-4f8c-478f-ae23-da88206a68ab">
<img width="345" alt="스크린샷 2024-03-05 오전 6 49 28" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/05b2e58f-6c9d-476e-a00e-0e10e4ef60f8">
<img width="365" alt="스크린샷 2024-03-05 오전 6 49 51" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/ea85dc94-5e6c-4771-8c86-7ac616a420fc">
