### PR TITLE
#270 [fix] 지원서 작성하기의 response data 형태 변경

### DIFF
--- a/src/main/java/com/moddy/server/controller/application/dto/response/ApplicationExpireDateResponse.java
+++ b/src/main/java/com/moddy/server/controller/application/dto/response/ApplicationExpireDateResponse.java
@@ -1,6 +1,6 @@
 package com.moddy.server.controller.application.dto.response;
 
 public record ApplicationExpireDateResponse(
-        String expireDate
+        String expirationDate
 ) {
 }

--- a/src/main/java/com/moddy/server/service/application/HairModelApplicationRegisterService.java
+++ b/src/main/java/com/moddy/server/service/application/HairModelApplicationRegisterService.java
@@ -42,7 +42,7 @@ public class HairModelApplicationRegisterService {
         savePreferHairStyles(applicationInfo, hairModelApplication);
         saveHairServiceRecords(applicationInfo, hairModelApplication);
 
-        return new ApplicationExpireDateResponse(hairModelApplication.getExpiredDate().format(DateTimeFormatter.ofPattern("yyyy. MM. dd.")));
+        return new ApplicationExpireDateResponse(hairModelApplication.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy. MM. dd")) + " - " + hairModelApplication.getExpiredDate().format(DateTimeFormatter.ofPattern("yyyy. MM. dd")));
     }
 
     @Transactional

--- a/src/main/java/com/moddy/server/service/application/HairModelApplicationRegisterService.java
+++ b/src/main/java/com/moddy/server/service/application/HairModelApplicationRegisterService.java
@@ -29,6 +29,7 @@ public class HairModelApplicationRegisterService {
     private final PreferHairStyleJpaRepository preferHairStyleJpaRepository;
     private final HairServiceRecordJpaRepository hairServiceRecordJpaRepository;
     private final ModelJpaRepository modelJpaRepository;
+    private static final String DATE_FORMAT = "yyyy. MM. dd";
 
     @Transactional
     public ApplicationExpireDateResponse postApplication(final Long modelId, final MultipartFile modelImgUrl, final MultipartFile applicationCaptureImgUrl, final ModelApplicationRequest applicationInfo) {
@@ -42,7 +43,7 @@ public class HairModelApplicationRegisterService {
         savePreferHairStyles(applicationInfo, hairModelApplication);
         saveHairServiceRecords(applicationInfo, hairModelApplication);
 
-        return new ApplicationExpireDateResponse(hairModelApplication.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy. MM. dd")) + " - " + hairModelApplication.getExpiredDate().format(DateTimeFormatter.ofPattern("yyyy. MM. dd")));
+        return new ApplicationExpireDateResponse(hairModelApplication.getCreatedDate().format(DateTimeFormatter.ofPattern(DATE_FORMAT)) + " - " + hairModelApplication.getExpiredDate().format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
     }
 
     @Transactional


### PR DESCRIPTION
## 관련 이슈번호
* Closes #270 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 10m/10m

## 해결하려는 문제가 무엇인가요?
* 지원서 작성하기의 response data의 형태가 예전 GUI/와프를 보고 했던것 같습니다~~!!
* 그래서 데이터 형태 다시 재조합해서 reutrn

## 어떻게 해결했나요?
<img width="474" alt="스크린샷 2024-03-06 오후 2 53 15" src="https://github.com/TEAM-MODDY/moddy-server/assets/62981652/aae5d6d8-cee9-4d13-9575-95138af1eadf">
