### PR TITLE
#293 [fix] 디자이너 메인뷰 페이징 정렬, total 계산 오류 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ output/
 *.ipr
 *.iws
 
-
 # OSX
 .DS_Store
 .AppleDouble
@@ -37,3 +36,5 @@ output/
 *.log-*.gz
 logs/
 
+#Token
+/src/main/java/com/moddy/server/TestController.java

--- a/src/main/java/com/moddy/server/domain/hair_model_application/repository/HairModelApplicationJpaRepository.java
+++ b/src/main/java/com/moddy/server/domain/hair_model_application/repository/HairModelApplicationJpaRepository.java
@@ -4,8 +4,11 @@ import com.moddy.server.domain.hair_model_application.HairModelApplication;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,5 +21,8 @@ public interface HairModelApplicationJpaRepository extends JpaRepository<HairMod
     Page<HairModelApplication> findAll(Pageable pageable);
 
     List<HairModelApplication> findAllByModelId(Long modelId);
+
+    @Query("SELECT COUNT(*) FROM HairModelApplication h WHERE h.createdAt >= :startDate AND h.createdAt < :endDate")
+    long countNonExpiredApplications(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
 }

--- a/src/main/java/com/moddy/server/service/application/HairModelApplicationRetrieveService.java
+++ b/src/main/java/com/moddy/server/service/application/HairModelApplicationRetrieveService.java
@@ -50,7 +50,6 @@ public class HairModelApplicationRetrieveService {
 
         Page<HairModelApplication> applicationPage = findApplicationsByPaging(page, size);
         long totalElements = applicationPage.getTotalElements();
-
         List<HairModelApplicationResponse> applicationResponsesList = applicationPage.stream().map(this::getApplicationResponse).collect(Collectors.toList());
 
         return new DesignerMainResponse(
@@ -139,14 +138,17 @@ public class HairModelApplicationRetrieveService {
         PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<HairModelApplication> applicationPage = hairModelApplicationJpaRepository.findAll(pageRequest);
 
-        long totalElements = applicationPage.getTotalElements();
+        long nonExpiredCount = hairModelApplicationJpaRepository.findAll()
+                    .stream()
+                    .filter(application -> !application.isExpired())
+                    .count();
 
         Page<HairModelApplication> nonExpiredApplications = applicationPage
                 .stream()
                 .filter(application -> !application.isExpired())
                 .collect(Collectors.collectingAndThen(
                         Collectors.toList(),
-                        list -> new PageImpl<>(list, pageRequest, totalElements)  // 전체 개수 사용
+                        list -> new PageImpl<>(list, pageRequest, nonExpiredCount)  // 전체 개수 사용
                 ));
 
         return nonExpiredApplications;

--- a/src/main/java/com/moddy/server/service/application/HairModelApplicationRetrieveService.java
+++ b/src/main/java/com/moddy/server/service/application/HairModelApplicationRetrieveService.java
@@ -28,6 +28,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -138,10 +140,7 @@ public class HairModelApplicationRetrieveService {
         PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<HairModelApplication> applicationPage = hairModelApplicationJpaRepository.findAll(pageRequest);
 
-        long nonExpiredCount = hairModelApplicationJpaRepository.findAll()
-                    .stream()
-                    .filter(application -> !application.isExpired())
-                    .count();
+        long nonExpiredCount = hairModelApplicationJpaRepository.countNonExpiredApplications(LocalDate.now().minusDays(13).atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay());
 
         Page<HairModelApplication> nonExpiredApplications = applicationPage
                 .stream()


### PR DESCRIPTION
## 관련 이슈번호
* Closes #293 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 15m/30m

## 해결하려는 문제가 무엇인가요?
* 정렬이 생성 날짜 별로 _ 최근것이 아니였다 => 정렬 기준 변경
* total 계산 오류 => non Expired 전체 계산히 total도 다시 계산 하도록 변경 

## 추가 개선 사항
* 어쩔 수 없이 expired 계산 처리후에 값을 가져와야한다 , 또한 offset방식으로 페이징 처리를 하고 있기 때문에 클라이언트에서 size를 넘어가게 되면 api 요청을 한번 더 하게 된다. 그러므로 total 개수 계산은 매번 이뤄져야한다. 
* 그래서 만료되지 않는 total 요소의 개수를 쿼리를 통해 가져올 수 있도록 했다.
* 인덱스를 생성하고, count h 대신에 count * 를 통해 B Tree가 요소 레이어까지 접근하지 않고 인덱스 개수만 조회해서 가져올 수 있도록.. 나름의 조회를 빠르게 할 수 있도록 했다. 

## Wanna Do 
오프셋 방식 말고... 커서 방식... need... 클라이언트와 이야기를 나눠야한다
사실 다 뜯어 고쳐서 최적화하고 싶지만 배포되어 있는 서비스에 문제가 발생한거라 추후 수정해야할듯
